### PR TITLE
S0 add heroku deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.tfstate
+*.backup
+terraform.tfvars    

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.tfstate
 *.backup
-terraform.tfvars    
+terraform.tfvars

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # eq-terraform
+
 Terraform project that creates the infrastructure for the EQ project alpha.
+
+## Setting up Terraform
+
+1. Install terraform(terraform.io) and add the binary to your shell path.
+
+2. Ensure that you have signed up for a heroku account and have generated an API
+key.
+
+3. Copy `terraform.tfvars.example` to `terraform.tfvars` and replace your heroku
+key in the file, adding your email address that you use to login with.
+
+4. Run `terraform plan -var 'env=testdeploy'` to check the output of terraform.
+
+5. Run `terraform apply -var 'env=DEPLOY_ENV'` to create your infrastructure
+environment.
+
+*Note* To destroy an environment, run `terraform destroy -var 'env=DEPLOY_ENV'`

--- a/eq_paas_deploy.tf
+++ b/eq_paas_deploy.tf
@@ -1,0 +1,31 @@
+# Configure the Heroku provider
+provider "heroku" {
+    email = "${var.heroku_email_account}"             
+    api_key = "${var.heroku_api_key}"
+}
+
+# Create our authoring app
+resource "heroku_app" "eq_author" {
+    name = "${var.env}-ons-eq-author"
+    region = "eu"
+
+    config_vars {
+        FOOBAR = "baz"
+    }
+}
+
+# Create a database, and configure the app to use it
+resource "heroku_addon" "database" {
+  app = "${heroku_app.eq_author.name}"
+  plan = "heroku-postgresql:hobby-basic"
+}
+
+# Create our executor
+resource "heroku_app" "eq-executor" {
+    name = "${var.env}-ons-eq-executor"
+    region = "eu"
+
+    config_vars {
+        SURVEY_REGISTRY_URL = "${heroku_app.eq_author.web_url}"
+    }
+}

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -1,0 +1,9 @@
+variable "heroku_email_account"  {
+    description = "Your Heroku email you use to login with."
+}
+variable "heroku_api_key" {
+     description = "Your heroku api key."
+}
+variable "env" {
+     description = "The environment you wish to use."
+}

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,2 @@
+heroku_email_account = "xxxx@xxxx"
+heroku_api_key = "XXXXXXXXXXXX"


### PR DESCRIPTION
__What__

This pull request creates the initial infrastructure for demoing the EQ(electronic questionnaire) project architecture. It consists of a terraform definition for two Heroku apps and a database attached to one. This is the first iteration of what we are trying to achieve with EQ infrastructure.

__How to test this PR__

On a linux or osx system, clone the repo and check out this branch. Following the instructions in the README, check that you can install Terraform and replicate the deployment of two heroku applications and verify that the database is attached to the author application. You may also wish to check that the correct environment variables have been injected into their respective environments.

__Who can test__

Anyone on the EQ team apart from @dhilton
