### PR TITLE
Add heroku app deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.tfstate
 *.backup
 terraform.tfvars
+tmp

--- a/deploy_author.sh
+++ b/deploy_author.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+AUTHOR_REPO_URL=https://github.com/ONSdigital/eq-author
+BRANCH=create-django-project-skeleton
+
+echo $AUTHOR_REPO_URL
+mkdir -p tmp
+cd ./tmp
+git clone $AUTHOR_REPO_URL
+cd ./eq-author
+git fetch
+git checkout $BRANCH
+heroku git:remote -a $1
+git push heroku $BRANCH:master

--- a/deploy_author.sh
+++ b/deploy_author.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 AUTHOR_REPO_URL=https://github.com/ONSdigital/eq-author
-BRANCH=create-django-project-skeleton
+BRANCH=master
 
 echo $AUTHOR_REPO_URL
 mkdir -p tmp
@@ -9,5 +9,6 @@ git clone $AUTHOR_REPO_URL
 cd ./eq-author
 git fetch
 git checkout $BRANCH
+git pull
 heroku git:remote -a $1
 git push heroku $BRANCH:master

--- a/deploy_surveyrunner.sh
+++ b/deploy_surveyrunner.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 SRUNNER_REPO_URL=https://github.com/ONSdigital/eq-survey-runner
+BRANCH=master
 
+echo $SRUNNER_REPO_URL
 mkdir -p tmp
 cd ./tmp
 git clone $SRUNNER_REPO_URL
 cd ./eq-survey-runner
+git fetch
+git checkout $BRANCH
 heroku git:remote -a $1
-git push heroku master
+git push heroku $BRANCH:master

--- a/deploy_surveyrunner.sh
+++ b/deploy_surveyrunner.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+SRUNNER_REPO_URL=https://github.com/ONSdigital/eq-survey-runner
+
+mkdir -p tmp
+cd ./tmp
+git clone $SRUNNER_REPO_URL
+cd ./eq-survey-runner
+heroku git:remote -a $1
+git push heroku master

--- a/deploy_surveyrunner.sh
+++ b/deploy_surveyrunner.sh
@@ -9,5 +9,6 @@ git clone $SRUNNER_REPO_URL
 cd ./eq-survey-runner
 git fetch
 git checkout $BRANCH
+git pull
 heroku git:remote -a $1
 git push heroku $BRANCH:master

--- a/eq_paas_deploy.tf
+++ b/eq_paas_deploy.tf
@@ -1,6 +1,6 @@
 # Configure the Heroku provider
 provider "heroku" {
-    email = "${var.heroku_email_account}"             
+    email = "${var.heroku_email_account}"
     api_key = "${var.heroku_api_key}"
 }
 
@@ -12,6 +12,10 @@ resource "heroku_app" "eq_author" {
     config_vars {
         FOOBAR = "baz"
     }
+    provisioner "local-exec" {
+       command = "./deploy_author.sh ${var.env}-ons-eq-author"
+   }
+
 }
 
 # Create a database, and configure the app to use it
@@ -21,11 +25,23 @@ resource "heroku_addon" "database" {
 }
 
 # Create our executor
-resource "heroku_app" "eq-executor" {
-    name = "${var.env}-ons-eq-executor"
+resource "heroku_app" "eq_surveyrunner" {
+    name = "${var.env}-ons-eq-surveyrunner"
     region = "eu"
 
     config_vars {
         SURVEY_REGISTRY_URL = "${heroku_app.eq_author.web_url}"
     }
+    # Use local provisioner to clone and push our app.
+    provisioner "local-exec" {
+       command = "./deploy_surveyrunner.sh ${var.env}-ons-eq-surveyrunner"
+   }
+}
+
+
+output "SurveyRunner" {
+    value = "${heroku_app.eq_surveyrunner.web_url}"
+}
+output "AuthorTool" {
+    value = "${heroku_app.eq_author.web_url}"
 }

--- a/eq_paas_deploy.tf
+++ b/eq_paas_deploy.tf
@@ -21,7 +21,7 @@ resource "heroku_app" "eq_author" {
 # Create a database, and configure the app to use it
 resource "heroku_addon" "database" {
   app = "${heroku_app.eq_author.name}"
-  plan = "heroku-postgresql:hobby-basic"
+  plan = "heroku-postgresql:hobby-dev"
 }
 
 # Create our executor

--- a/smoke_tests.tf
+++ b/smoke_tests.tf
@@ -1,0 +1,13 @@
+# Simplistic smoke test run
+# A little bit of a hack to execute.
+
+resource "template_file" "smoke_test" {
+    filename = "smokey.sh"
+    vars {
+        noop = "This test may take a while for dynamos to spin up..."
+    }
+
+    provisioner "local-exec" {
+      command = "./smokey.sh ${heroku_app.eq_surveyrunner.web_url} ${heroku_app.eq_author.web_url}"
+      }
+}

--- a/smokey.sh
+++ b/smokey.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Check that we get a http 200 from each web application
+# @todo - move this to https://github.com/ryotarai/infrataster
+
+srunner_response=$(curl --write-out %{http_code} -L --silent --output /dev/null $1)
+author_response=$(curl --write-out %{http_code} -L --silent --output /dev/null $2)
+
+if [[ $srunner_response == 200 && $author_response == 200 ]]; then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
__What__

This pull request should be consider in the context of the sprint 0 story of technical setup of our systems. This PR implements a new provision step as part of our Terraform code to provision our applications (eq-author and eq-surveyrunner) to their respective heroku applications. It then runs a set of very simple smoke tests to assert that the provisioning has been successful.

__How to test__

To test this PR, destroy any existing environments and deploy a new environment. You should be presented with two urls that resolve and return status code 200.

__Who can test__

Anyone but @dhilton
