### PR TITLE
DIGEQ-55 Adding Dockerfile for nginx, configured to proxy all request…

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx
+COPY eq-survey-runner.conf eq-survey-runner.conf
+COPY start-nginx.sh start-nginx.sh
+CMD bash start-nginx.sh
+

--- a/nginx/eq-survey-runner.conf
+++ b/nginx/eq-survey-runner.conf
@@ -1,0 +1,11 @@
+server {
+    listen 8082;
+    server_name eq-survey-runner;
+    access_log  /var/log/nginx/eq-survey-runner.log;
+
+    location / {
+        proxy_pass http://eqsurveyrunner;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/nginx/start-nginx.sh
+++ b/nginx/start-nginx.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Preprend upstream config for the survey runner
+(echo "upstream eqsurveyrunner { server $EQ_SURVEY_RUNNER_PORT_8080_TCP_ADDR:$EQ_SURVEY_RUNNER_PORT_8080_TCP_PORT; }" && cat eq-survey-runner.conf) > eq-survey-runner.conf.new
+mv eq-survey-runner.conf.new /etc/nginx/conf.d/eq-survey-runner.conf
+
+# Start nginx
+echo "daemon off;" >> /etc/nginx/nginx.conf
+service nginx restart


### PR DESCRIPTION
**What**
NGINX docker image configured to proxy to the eq-survey runner

**How to test**
1 Check out the eq-survey runner project and build it's docker image:  docker build -t eq-survey-runner ../eq-survey-runner/
2. Check out this branch
3. Build the docker image docker build -t eq-survey-runner-nginx ./nginx/
4. Run the eq-survey-runner docker image: `docker run -d -p 8080:8080 --name eq-survey-runner eq-survey-runner`
5 Run the nginx docker image: `docker run -d -p 8081:8082 --name eq-survey-runner-nginx --link eq-survey-runner eq-survey-runner-nginx`
6. Service should be accessible on http://localhost:8080/ and http://localhost:8081/

**Who can test**
Anyone apart from @warren-methods

