### PR TITLE
Create domains for author and survey in r53

### DIFF
--- a/domains.tf
+++ b/domains.tf
@@ -1,0 +1,15 @@
+resource "aws_route53_record" "runner" {
+  zone_id = "${var.dns_zone_id}"
+  name = "${var.env}-survey.${var.dns_zone_name}"
+  type = "CNAME"
+  ttl = "60"
+  records = ["${aws_elb.ecs_lb.dns_name}"]
+}
+
+resource "aws_route53_record" "author" {
+  zone_id = "${var.dns_zone_id}"
+  name = "${var.env}-author.${var.dns_zone_name}"
+  type = "CNAME"
+  ttl = "60"
+  records = ["${heroku_app.eq_author.heroku_hostname}"]
+}

--- a/eq-survey-runner-deploy.tf
+++ b/eq-survey-runner-deploy.tf
@@ -49,7 +49,7 @@ resource "template_file" "survey_runner_task" {
   filename = "aws/task-definitions/eq-survey-runner.json"
 
   vars {
-    survey_registry_url   = "${heroku_app.eq_author.web_url}"
+    survey_registry_url   = "${aws_route53_record.author.fqdn}"
   }
 }
 
@@ -141,6 +141,6 @@ resource "aws_security_group" "ecs" {
 }
 
 
-output "SurveyURL" {
+output "SurveyURL " {
     value = "http://${var.env}-survey.eq.ons.digital/"
 }

--- a/eq-survey-runner-deploy.tf
+++ b/eq-survey-runner-deploy.tf
@@ -141,6 +141,6 @@ resource "aws_security_group" "ecs" {
 }
 
 
-output "SurveyRunner" {
-    value = "http://${aws_elb.ecs_lb.dns_name}"
+output "SurveyURL" {
+    value = "http://${var.env}-survey.eq.ons.digital/"
 }

--- a/eq_paas_deploy.tf
+++ b/eq_paas_deploy.tf
@@ -10,7 +10,7 @@ resource "heroku_app" "eq_author" {
     region = "eu"
 
     config_vars {
-        SURVEY_RUNNER_URL ="http://${aws_elb.ecs_lb.dns_name}/"
+        SURVEY_RUNNER_URL = "${aws_route53_record.runner.fqdn}"
     }
     provisioner "local-exec" {
        command = "./deploy_author.sh ${var.env}-ons-eq-author"

--- a/eq_paas_deploy.tf
+++ b/eq_paas_deploy.tf
@@ -24,11 +24,12 @@ resource "heroku_addon" "database" {
   plan = "heroku-postgresql:hobby-dev"
 }
 
+# Associate a custom domain
+resource "heroku_domain" "default" {
+    app = "${heroku_app.eq_author.name}"
+    hostname = "${aws_route53_record.author.fqdn}"
+}
 
-
-#output "SurveyRunner" {
-#    value = "${heroku_app.eq_surveyrunner.web_url}"
-#}
-output "AuthorTool" {
-    value = "${heroku_app.eq_author.web_url}"
+output "AuthorURL" {
+    value = "http://${var.env}-author.eq.ons.digital/"
 }

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -24,3 +24,12 @@ variable "aws_key_pair" {
 variable "aws_instance_type" {
     description = "Amazon instance type to spin up"
 }
+variable "dns_zone_id" {
+  description = "Amazon Route53 DNS zone identifier"
+  default = "Z34V7YH0QGSCUI"
+}
+
+variable "dns_zone_name" {
+  description = "Amazon Route53 DNS zone name"
+  default     = "eq.ons.digital."
+}


### PR DESCRIPTION
__What__
This commit creates two new route 53 domain records, allowing us to
point those at the created infrastructure on Heroku and AWS.

The new domain for the author app is also registered with Heroku
so that they can route accordingly.

__How to test__

1. Check out this branch
2. Create a new environment
3. Check the urls given at the end of the terraform run resolve to the correct author and survey runner instances.
4. Tear down that environment
5. Check in the AWS console that all the Route 53 records have been purged.

__Who can test__

Anyone but @dhilton 

