### PR TITLE
DIGEQ-133 Terraform configuration to support storing responses in an S3 bucket

### DIFF
--- a/aws/task-definitions/eq-survey-runner.json
+++ b/aws/task-definitions/eq-survey-runner.json
@@ -1,74 +1,84 @@
 [
-  {
-    "name": "eq-survey-runner",
-    "image": "onsdigital/eq-survey-runner",
-    "cpu": 340,
-    "memory": 512,
-    "essential": true,
-    "links": ["cassandra"],
-    "environment": [
-      {
-        "name": "SURVEY_REGISTRY_URL",
-        "value": "${survey_registry_url}"
-      }
-    ],
-    "portMappings": [
-      {
-        "containerPort": 8080,
-        "hostPort": 8080
-      }
-    ]
-  },
-  {
-    "name": "nginx",
-    "image": "onsdigital/eq-terraform",
-    "cpu": 340,
-    "memory": 512,
-    "essential": true,
-    "links": ["eq-survey-runner"],
-    "portMappings": [
-      {
-        "containerPort": 8082,
-        "hostPort": 8082
-      }
-    ]
-  },
-  {
-    "name": "cassandra",
-    "image": "spotify/cassandra",
-    "cpu": 340,
-    "memory": 512,
-    "essential": true,
-     "portMappings": [
-      {
-        "containerPort": 7199,
-        "hostPort": 7199
-      },
-      {
-        "containerPort": 7000,
-        "hostPort": 7000
-      } ,
-      {
-        "containerPort": 7001,
-        "hostPort": 7001
-      } ,
-      {
-        "containerPort": 9160,
-        "hostPort": 9160
-      } ,
-      {
-        "containerPort": 9042,
-        "hostPort": 9042
-      } ,
-      {
-        "containerPort": 8012,
-        "hostPort": 8012
-      } ,
-      {
-        "containerPort": 61621,
-        "hostPort": 61621
-      }
-
-    ]
-  }
+    {
+      "name": "eq-survey-runner",
+      "image": "onsdigital/eq-survey-runner",
+      "cpu": 340,
+      "memory": 512,
+      "essential": true,
+      "links": [
+        "cassandra"
+      ],
+      "environment": [
+        {
+          "name": "SURVEY_REGISTRY_URL",
+          "value": "${survey_registry_url}"
+        }
+      ],
+      "mountPoints": [
+        {
+          "sourceVolume": "awscredentials",
+          "containerPath": "/root/.aws",
+          "readOnly": true
+        }
+      ],
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "hostPort": 8080
+        }
+      ]
+    },
+    {
+      "name": "nginx",
+      "image": "onsdigital/eq-terraform",
+      "cpu": 340,
+      "memory": 512,
+      "essential": true,
+      "links": [
+        "eq-survey-runner"
+      ],
+      "portMappings": [
+        {
+          "containerPort": 8082,
+          "hostPort": 8082
+        }
+      ]
+    },
+    {
+      "name": "cassandra",
+      "image": "spotify/cassandra",
+      "cpu": 340,
+      "memory": 512,
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 7199,
+          "hostPort": 7199
+        },
+        {
+          "containerPort": 7000,
+          "hostPort": 7000
+        },
+        {
+          "containerPort": 7001,
+          "hostPort": 7001
+        },
+        {
+          "containerPort": 9160,
+          "hostPort": 9160
+        },
+        {
+          "containerPort": 9042,
+          "hostPort": 9042
+        },
+        {
+          "containerPort": 8012,
+          "hostPort": 8012
+        },
+        {
+          "containerPort": 61621,
+          "hostPort": 61621
+        }
+      ]
+    }
 ]

--- a/eq-survey-runner-deploy.tf
+++ b/eq-survey-runner-deploy.tf
@@ -15,7 +15,7 @@ resource "aws_launch_configuration" "ecs-lc" {
   key_name             = "${var.aws_key_pair}"
   security_groups      = ["${aws_security_group.ecs.id}"]
   iam_instance_profile = "${aws_iam_instance_profile.ecs.name}"
-  user_data            = "#!/bin/bash\necho ECS_CLUSTER=${var.env} > /etc/ecs/ecs.config; \nmkdir /home/ec2-user/.aws; \necho '[default]\naws_access_key_id = ${var.aws_access_key}\naws_secret_access_key = ${var.aws_secret_key}' > /home/ec2-user/.aws/credentials"
+  user_data            = "#!/bin/bash\necho ECS_CLUSTER=${var.env} > /etc/ecs/ecs.config; \nmkdir /home/ec2-user/.aws; \necho '[default]\naws_access_key_id = ${var.aws_access_key}\naws_secret_access_key = ${var.aws_secret_key}' > /home/ec2-user/.aws/credentials; \necho '[default]\nregion = eu-west-1' > /home/ec2-user/.aws/config"
 }
 
 resource "aws_autoscaling_group" "ecs-ag" {
@@ -56,7 +56,10 @@ resource "template_file" "survey_runner_task" {
 resource "aws_ecs_task_definition" "eq-survey-task" {
   family = "deq-task-${var.env}"
   container_definitions = "${template_file.survey_runner_task.rendered}"
-
+  volume {
+    name = "awscredentials"
+    host_path = "/home/ec2-user/.aws"
+  }
 }
 
 # Create a new load balancer

--- a/eq-survey-runner-deploy.tf
+++ b/eq-survey-runner-deploy.tf
@@ -15,7 +15,7 @@ resource "aws_launch_configuration" "ecs-lc" {
   key_name             = "${var.aws_key_pair}"
   security_groups      = ["${aws_security_group.ecs.id}"]
   iam_instance_profile = "${aws_iam_instance_profile.ecs.name}"
-  user_data            = "#!/bin/bash\necho ECS_CLUSTER=${var.env} > /etc/ecs/ecs.config"
+  user_data            = "#!/bin/bash\necho ECS_CLUSTER=${var.env} > /etc/ecs/ecs.config; \nmkdir /home/ec2-user/.aws; \necho '[default]\naws_access_key_id = ${var.aws_access_key}\naws_secret_access_key = ${var.aws_secret_key}' > /home/ec2-user/.aws/credentials"
 }
 
 resource "aws_autoscaling_group" "ecs-ag" {


### PR DESCRIPTION
**What**
This change copies the users aws access/secret keys to the aws instances on deployment. It then mounts them in the survey runner docker container. This will allow the survey runner to store responses in an S3 bucket.

**Dependencies**
These two pull request must be merged first.
1. https://github.com/ONSdigital/eq-survey-runner/pull/60
2. https://github.com/ONSdigital/eq-survey-runner/pull/60

**How to test**
1. `terraform apply -var 'env=test'
2. Log into the aws instance
3. Check that the /home/ec2-user/.aws directory exists and contains two files (credentials and config)
4. Check the files contain the expected aws keys
5. Connect to the survey runner docker container  `docker exec -it <container-id> bash`
6. Check the files are mapped to /root/.aws

**Who can test**
Anyone apart from @warren-methods