### PR TITLE
Terraform files for provisioning Rabbit MQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+rendered
+tmp
+.idea
+terraform.tfstate
+terraform.tfstate.backup
+terraform.tfvars
+pre-prod.pem
+

--- a/README.md
+++ b/README.md
@@ -15,13 +15,8 @@ Also the pre-prod.pem key must exist in this directory.
 
 1. Install terraform(terraform.io) and add the binary to your shell path.
 
-2. Ensure that you have signed up for a heroku account and have generated an API
-key.
-
-3. Copy `terraform.tfvars.example` to `terraform.tfvars` and replace your heroku
-key in the file, adding your email address that you use to login with.
+2. Copy `terraform.tfvars.example` to `terraform.tfvars`
 
 4. Run `terraform plan` to check the output of terraform.
 
-5. Run `terraform apply` to create your infrastructure
-environment.
+5. Run `terraform apply` to create your infrastructure environment.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Terraform project that creates the infrastructure for the EQ project alpha.
 
+## Pre-requisites
+
+The following programs must be installed:
+
+1. Git
+2. Ansible
+
+Also the pre-prod.pem key must exist in this directory.
+
 ## Setting up Terraform
 
 1. Install terraform(terraform.io) and add the binary to your shell path.
@@ -12,7 +21,7 @@ key.
 3. Copy `terraform.tfvars.example` to `terraform.tfvars` and replace your heroku
 key in the file, adding your email address that you use to login with.
 
-4. Run `terraform plan -var 'env=testdeploy'` to check the output of terraform.
+4. Run `terraform plan` to check the output of terraform.
 
-5. Run `terraform apply -var 'env=testdeploy'` to create your infrastructure
+5. Run `terraform apply` to create your infrastructure
 environment.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # eq-terraform
+
+Terraform project that creates the infrastructure for the EQ project alpha.
+
+## Setting up Terraform
+
+1. Install terraform(terraform.io) and add the binary to your shell path.
+
+2. Ensure that you have signed up for a heroku account and have generated an API
+key.
+
+3. Copy `terraform.tfvars.example` to `terraform.tfvars` and replace your heroku
+key in the file, adding your email address that you use to login with.
+
+4. Run `terraform plan -var 'env=testdeploy'` to check the output of terraform.
+
+5. Run `terraform apply -var 'env=testdeploy'` to create your infrastructure
+environment.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ Also the pre-prod.pem key must exist in this directory.
 4. Run `terraform plan` to check the output of terraform.
 
 5. Run `terraform apply` to create your infrastructure environment.
+
+## Troubleshooting
+
+1. If your build fails make sure the tmp directory has been deleted.
+2. If the build stalls on the ssh step waiting for user input set the following in your ~/.ssh/config file
+    `StrictHostKeyChecking no`
+    `UserKnownHostsFile /dev/null`

--- a/deploy.tf
+++ b/deploy.tf
@@ -1,0 +1,169 @@
+provider "aws" {
+    access_key = "${var.aws_access_key}"
+    secret_key = "${var.aws_secret_key}"
+    region = "eu-west-1"
+}
+
+resource "aws_instance" "rabbitmq1" {
+    ami = "ami-47a23a30"
+    instance_type = "t2.small"
+    key_name = "${var.aws_key_pair}"
+
+    tags {
+        Name = "RabbitMQ 1"
+    }
+
+    security_groups = ["${aws_security_group.allow_all.name}"]
+}
+
+
+resource "aws_instance" "rabbitmq2" {
+    ami = "ami-47a23a30"
+    instance_type = "t2.small"
+    key_name = "${var.aws_key_pair}"
+
+    tags {
+        Name = "RabbitMQ 2"
+    }
+
+    security_groups = ["${aws_security_group.allow_all.name}"]
+
+}
+
+resource "template_file" "hosts" {
+    template = "${file("templates/hosts")}"
+    vars= {
+        rabbitmq1_ip = "${aws_instance.rabbitmq1.private_ip}"
+        rabbitmq2_ip = "${aws_instance.rabbitmq2.private_ip}"
+    }
+}
+
+resource "template_file" "hostname-rabbitmq1" {
+    template = "${file("templates/hostname")}"
+    vars {
+        hostname = "rabbitmq1"
+    }
+}
+
+resource "template_file" "hostname-rabbitmq2" {
+    template = "${file("templates/hostname")}"
+    vars {
+        hostname = "rabbitmq2"
+    }
+}
+
+resource "null_resource" "aws_hosts" {
+
+    provisioner "local-exec" {
+        command = "echo '${template_file.hosts.rendered}' > rendered/hosts"
+    }
+
+    provisioner "local-exec" {
+        command = "echo ${template_file.hostname-rabbitmq1.rendered} > rendered/hostname-rabbitmq1"
+    }
+
+    provisioner "local-exec" {
+        command = "echo ${template_file.hostname-rabbitmq2.rendered} > rendered/hostname-rabbitmq2"
+    }
+
+    provisioner "file" {
+        source = "rendered/hosts"
+        destination = "/home/ubuntu/hosts"
+        connection {
+            type="ssh"
+            user = "ubuntu"
+            host = "${aws_instance.rabbitmq1.public_ip}"
+            private_key = "${file("pre-prod.pem")}"
+            agent = false
+        }
+    }
+
+    provisioner "file" {
+        source = "rendered/hostname-rabbitmq1"
+        destination = "/home/ubuntu/hostname"
+        connection {
+            type = "ssh"
+            user = "ubuntu"
+            host = "${aws_instance.rabbitmq1.public_ip}"
+            private_key = "${file("pre-prod.pem")}"
+            agent = false
+        }
+    }
+
+    provisioner "file" {
+        source = "rendered/hosts"
+        destination = "/home/ubuntu/hosts"
+        connection {            type = "ssh"
+            user = "ubuntu"
+            host = "${aws_instance.rabbitmq2.public_ip}"
+            private_key = "${file("pre-prod.pem")}"
+            agent = false
+        }
+    }
+
+    provisioner "file" {
+        source = "rendered/hostname-rabbitmq2"
+        destination = "/home/ubuntu/hostname"
+        connection {
+            type="ssh"
+            user = "ubuntu"
+            host = "${aws_instance.rabbitmq2.public_ip}"
+            private_key = "${file("pre-prod.pem")}"
+            agent = false
+        }
+    }
+
+     provisioner "remote-exec" {
+        inline = [
+            "sudo cp hostname /etc/hostname",
+            "sudo cp hosts /etc/hosts",
+            "sudo hostname -F /etc/hostname"
+        ]
+        connection {
+            type="ssh"
+            user = "ubuntu"
+            host = "${aws_instance.rabbitmq1.public_ip}"
+            private_key = "${file("pre-prod.pem")}"
+            agent = false
+        }
+    }
+
+     provisioner "remote-exec" {
+        inline = [
+            "sudo cp hostname /etc/hostname",
+            "sudo cp hosts /etc/hosts",
+            "sudo hostname -F /etc/hostname"
+        ]
+        connection {
+            type="ssh"
+            user = "ubuntu"
+            host = "${aws_instance.rabbitmq2.public_ip}"
+            private_key = "${file("pre-prod.pem")}"
+            agent = false
+        }
+    }
+}
+
+resource "aws_security_group" "allow_all" {
+  name = "allow_all"
+  description = "Allow all inbound traffic"
+
+    ingress {
+      from_port = 0
+      to_port = 0
+      protocol = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    egress {
+      from_port = 0
+      to_port = 0
+      protocol = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    tags {
+        Name = "Terraform Allow All"
+    }
+}
+

--- a/deploy.tf
+++ b/deploy.tf
@@ -35,6 +35,7 @@ resource "template_file" "hosts" {
     vars= {
         rabbitmq1_ip = "${aws_instance.rabbitmq1.private_ip}"
         rabbitmq2_ip = "${aws_instance.rabbitmq2.private_ip}"
+        deploy_env    = "${var.env}"
     }
 }
 
@@ -203,4 +204,3 @@ resource "aws_security_group" "allow_all" {
         Name = "Terraform Allow All"
     }
 }
-

--- a/deploy.tf
+++ b/deploy.tf
@@ -87,7 +87,7 @@ resource "null_resource" "ansible" {
 
 resource "aws_route53_record" "rabbitmq1" {
   zone_id = "${var.dns_zone_id}"
-  name = "${var.env}-rabbitmq.0.${var.dns_zone_name}"
+  name = "${var.env}-rabbitmq1.${var.dns_zone_name}"
   type = "CNAME"
   ttl = "60"
   records = ["${aws_instance.rabbitmq.0.public_dns}"]
@@ -95,7 +95,7 @@ resource "aws_route53_record" "rabbitmq1" {
 
 resource "aws_route53_record" "rabbitmq2" {
   zone_id = "${var.dns_zone_id}"
-  name = "${var.env}-rabbitmq.1.${var.dns_zone_name}"
+  name = "${var.env}-rabbitmq2.${var.dns_zone_name}"
   type = "CNAME"
   ttl = "60"
   records = ["${aws_instance.rabbitmq.1.public_dns}"]

--- a/deploy.tf
+++ b/deploy.tf
@@ -10,7 +10,7 @@ resource "aws_instance" "rabbitmq1" {
     key_name = "${var.aws_key_pair}"
 
     tags {
-        Name = "RabbitMQ 1"
+        Name = "RabbitMQ 1 ${var.env}"
     }
 
     security_groups = ["${aws_security_group.allow_all.name}"]
@@ -23,7 +23,7 @@ resource "aws_instance" "rabbitmq2" {
     key_name = "${var.aws_key_pair}"
 
     tags {
-        Name = "RabbitMQ 2"
+        Name = "RabbitMQ 2 ${var.env}"
     }
 
     security_groups = ["${aws_security_group.allow_all.name}"]
@@ -150,14 +150,14 @@ resource "null_resource" "aws_hosts" {
 }
 
 resource "null_resource" "ansible" {
-   depends_on = ["null_resource.aws_hosts"]
+    depends_on = ["null_resource.aws_hosts"]
 
-   provisioner "local-exec" {
-        command = "git clone https://github.com/ONSdigital/eq-messaging.git tmp/eq-messaging"
+    provisioner "local-exec" {
+      command = "git clone https://github.com/ONSdigital/eq-messaging.git tmp/eq-messaging"
     }
 
     provisioner "local-exec" {
-        command = "ansible-playbook --private-key pre-prod.pem tmp/eq-messaging/ansible/rabbitmq-cluster.yml"
+      command = "ansible-playbook --private-key pre-prod.pem tmp/eq-messaging/ansible/rabbitmq-cluster.yml"
     }
 
     provisioner "local-exec" {
@@ -167,7 +167,7 @@ resource "null_resource" "ansible" {
 
 resource "aws_route53_record" "rabbitmq1" {
   zone_id = "${var.dns_zone_id}"
-  name = "rabbitmq1.${var.dns_zone_name}"
+  name = "${var.env}-rabbitmq1.${var.dns_zone_name}"
   type = "CNAME"
   ttl = "60"
   records = ["${aws_instance.rabbitmq1.public_dns}"]
@@ -175,14 +175,14 @@ resource "aws_route53_record" "rabbitmq1" {
 
 resource "aws_route53_record" "rabbitmq2" {
   zone_id = "${var.dns_zone_id}"
-  name = "rabbitmq2.${var.dns_zone_name}"
+  name = "${var.env}-rabbitmq2.${var.dns_zone_name}"
   type = "CNAME"
   ttl = "60"
   records = ["${aws_instance.rabbitmq2.public_dns}"]
 }
 
 resource "aws_security_group" "allow_all" {
-  name = "allow_all"
+  name = "allow_all-${var.env}"
   description = "Allow all inbound traffic"
 
     ingress {

--- a/deploy.tf
+++ b/deploy.tf
@@ -36,7 +36,7 @@ resource "null_resource" "aws_hosts" {
      provisioner "remote-exec" {
         inline = [
             "sudo sh -c 'echo ${var.env}-rabbitmq1 > /etc/hostname'",
-            "sudo sh -c 'echo ${template_file.hosts.rendered} > /etc/hosts'",
+            "sudo sh -c '${template_file.hosts.rendered} \n cat /etc/hosts'",
             "sudo hostname -F /etc/hostname"
         ]
         connection {
@@ -51,7 +51,7 @@ resource "null_resource" "aws_hosts" {
      provisioner "remote-exec" {
         inline = [
             "sudo sh -c 'echo ${var.env}-rabbitmq2 > /etc/hostname'",
-            "sudo sh -c 'echo ${template_file.hosts.rendered} > /etc/hosts'",
+            "sudo sh -c '${template_file.hosts.rendered} \n cat /etc/hosts'",
             "sudo hostname -F /etc/hostname"
         ]
         connection {
@@ -77,9 +77,9 @@ resource "null_resource" "ansible" {
     }
 
     provisioner "local-exec" {
-      command = "ansible-playbook --private-key pre-prod.pem tmp/eq-messaging/ansible/rabbitmq-cluster.yml --extra-vars \"deploy_env=${var.env}\""
+      command = "ansible-playbook -i '${var.env}-rabbitmq1.eq.ons.digital,${var.env}-rabbitmq2.eq.ons.digital'  --private-key pre-prod.pem tmp/eq-messaging/ansible/rabbitmq-cluster.yml --extra-vars \"deploy_env=${var.env}\""
     }
-
+    # ansible-playbook -i "dan-rabbitmq1.eq.ons.digital,dan-rabbitmq2.eq.ons.digital" --private-key ../eq-terraform/pre-prod.pem -v ansible/rabbitmq-cluster.yml --extra-vars "deploy_env=dan"
     provisioner "local-exec" {
       command = "rm -rf tmp"
     }

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -1,0 +1,12 @@
+variable "aws_secret_key" {
+    description = "Amazon Web Service Secret Key."
+}
+
+variable "aws_access_key"  {
+    description = "Amazon Web Service Access Key;"
+}
+
+variable "aws_key_pair" {
+    description = "Amazon Web Service Key Pair;"
+    default="pre-prod"
+}

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -1,3 +1,7 @@
+variable "env" {
+     description = "The environment you wish to use."
+}
+
 variable "aws_secret_key" {
     description = "Amazon Web Service Secret Key."
 }

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -10,3 +10,13 @@ variable "aws_key_pair" {
     description = "Amazon Web Service Key Pair;"
     default="pre-prod"
 }
+
+variable "dns_zone_id" {
+  description = "Amazon Route53 DNS zone identifier"
+  default = "Z2XIERRF1SJEYP"
+}
+
+variable "dns_zone_name" {
+  description = "Amazon Route53 DNS zone name"
+  default     = "eq.ons.digital."
+}

--- a/templates/hostname
+++ b/templates/hostname
@@ -1,0 +1,1 @@
+${hostname}

--- a/templates/hosts
+++ b/templates/hosts
@@ -1,6 +1,6 @@
 127.0.0.1 localhost
-${rabbitmq1_ip} rabbitmq1.eq.ons.digital rabbitmq1
-${rabbitmq2_ip} rabbitmq2.eq.ons.digital rabbitmq2
+${rabbitmq1_ip} ${deploy_env}-rabbitmq1.eq.ons.digital rabbitmq1
+${rabbitmq2_ip} ${deploy_env}-rabbitmq2.eq.ons.digital rabbitmq2
 
 
 # The following lines are desirable for IPv6 capable hosts

--- a/templates/hosts
+++ b/templates/hosts
@@ -1,0 +1,12 @@
+127.0.0.1 localhost
+${rabbitmq1_ip} rabbitmq1.eq.ons.digital rabbitmq1
+${rabbitmq2_ip} rabbitmq2.eq.ons.digital rabbitmq2
+
+
+# The following lines are desirable for IPv6 capable hosts
+::1 ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+ff02::3 ip6-allhosts

--- a/templates/hosts
+++ b/templates/hosts
@@ -1,6 +1,6 @@
 127.0.0.1 localhost
-${rabbitmq1_ip} ${deploy_env}-rabbitmq1.eq.ons.digital rabbitmq1
-${rabbitmq2_ip} ${deploy_env}-rabbitmq2.eq.ons.digital rabbitmq2
+${rabbitmq1_ip} ${deploy_env}-rabbitmq1.eq.ons.digital ${deploy_env}-rabbitmq1
+${rabbitmq2_ip} ${deploy_env}-rabbitmq2.eq.ons.digital ${deploy_env}-rabbitmq2
 
 
 # The following lines are desirable for IPv6 capable hosts

--- a/templates/hosts
+++ b/templates/hosts
@@ -10,3 +10,4 @@ ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 ff02::3 ip6-allhosts
+EOL

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,3 +1,3 @@
 aws_access_key="XXXXXXXXXXXX"
 aws_secret_key="XXXXXXXXXXXX"
-aws_key_pair="digital-eq-keypair"
+aws_key_pair="pre-prod"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,3 @@
+aws_access_key="XXXXXXXXXXXX"
+aws_secret_key="XXXXXXXXXXXX"
+aws_key_pair="digital-eq-keypair"


### PR DESCRIPTION
**What**
This pull requests does the following:
1. Creates two amazon instances
2. Reconfigurez the /etc/hosts and /etc/hostname files and set one to RabbitMQ1 and the other to RabbitMQ2
3. Creates two Route 53 entries; rabbitmq1.eq.ons.digital and rabbitmq2.eq.ons.digital
4. Executes an Ansible playbook to provision the two instances using the eq-messaging git hub repository.

**How to test**
1. Follow the steps in the README to set up terraform. (Essentially create a terraform.tfvars file using the example file, copy in the pre-prod key pair and install git and ansible).
2. Execute `terraform plan` and then `terraform apply`
3. Finally clean up using `terraform destroy`

**Who can review**
Anyone apart from @warrenbailey
