### PR TITLE
Fix elasticbeanstalk vpc

### DIFF
--- a/message_queue.tf
+++ b/message_queue.tf
@@ -15,6 +15,8 @@ resource "aws_instance" "rabbitmq" {
 resource "aws_elb" "rabbitmq" {
   name = "${var.env}-rabbitmq-elb"
   subnets = ["${aws_subnet.default.id}"]
+  security_groups = ["${aws_security_group.default.id}"]
+  internal = true
 
   listener {
     instance_port = 5672

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -9,6 +9,18 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
   solution_stack_name = "64bit Amazon Linux 2015.09 v2.0.6 running Python 3.4"
 
   setting {
+    namespace = "aws:ec2:vpc"
+    name      =  "VPCId"
+    value     = "${aws_vpc.default.id}"
+  }
+
+  setting {
+    namespace = "aws:ec2:vpc"
+    name      = "Subnets"
+    value     = "${aws_subnet.default.id}"
+  }
+
+  setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "SR_ENVIRONMENT"
     value     = "${var.survey_runner_env}"


### PR DESCRIPTION
**What**

This PR fixes the bug discovered when the elastic beanstalk instance can not communicate with the RabbitMQ instances via an ELB. 

The fixes:
- Explicitly add the EB instance to our VPC
- Add the same subnet and security group to our ELB allowing it to talk to the rabbitmq instances and
  the EB instance to talk to it.

**How to test**
1. Checkout this branch and create a new environment. 
2. Check the healthcheck url for the survey runner reports correctly that it can send a message.

**Who can review**

Anyone but @dhilton
