### PR TITLE
Add rabbitmq users

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -47,3 +47,32 @@ variable "survey_runner_env" {
   description = "The name of the survey runner environment, which is set as a environment variable."
   default     = "development"
 }
+
+variable "aws_default_region" {
+  description = "The default region for AWS Services"
+  default     = "eu-west-1"
+}
+
+variable "rabbitmq_admin_user" {
+  description = "The admin user to create for rabbitmq"
+}
+
+variable "rabbitmq_admin_password" {
+  description = "The admin user password for rabbitmq"
+}
+
+variable "rabbitmq_read_user" {
+  description = "The 'read-only' user to create for rabbitmq"
+}
+
+variable "rabbitmq_read_password" {
+  description = "The 'read-only' user password for rabbitmq"
+}
+
+variable "rabbitmq_write_user" {
+  description = "The 'write-only' user to create for rabbitmq"
+}
+
+variable "rabbitmq_write_password" {
+  description = "The 'write-only' user password for rabbitmq"
+}

--- a/message_queue.tf
+++ b/message_queue.tf
@@ -138,7 +138,7 @@ resource "null_resource" "ansible" {
     }
 
     provisioner "local-exec" {
-      command = "ansible-playbook -i '${var.env}-rabbitmq1.eq.ons.digital,${var.env}-rabbitmq2.eq.ons.digital'  --private-key pre-prod.pem tmp/eq-messaging/ansible/rabbitmq-cluster.yml --extra-vars \"deploy_env=${var.env}\""
+      command = "ansible-playbook -i '${var.env}-rabbitmq1.eq.ons.digital,${var.env}-rabbitmq2.eq.ons.digital'  --private-key pre-prod.pem tmp/eq-messaging/ansible/rabbitmq-cluster.yml --extra-vars '{\"deploy_env\":\"${var.env}\",\"rabbitmq_admin_user\":\"${var.rabbitmq_admin_user}\",\"rabbitmq_admin_password\":\"${var.rabbitmq_admin_password}\",\"rabbitmq_write_user\":\"${var.rabbitmq_write_user}\",\"rabbitmq_write_password\":\"${var.rabbitmq_write_password}\",\"rabbitmq_read_user\":\"${var.rabbitmq_read_user}\",\"rabbitmq_read_password\":\"${var.rabbitmq_read_password}\"}'"
     }
     # ansible-playbook -i "dan-rabbitmq1.eq.ons.digital,dan-rabbitmq2.eq.ons.digital" --private-key ../eq-terraform/pre-prod.pem -v ansible/rabbitmq-cluster.yml --extra-vars "deploy_env=dan"
     provisioner "local-exec" {


### PR DESCRIPTION
**_What**_

Adds support for adding rabbitmq users.  Requires support in eq-messaging

**_How to test**_

You will need to set a number of variables in the `terraform.tfvars` file. These are:

```
rabbitmq_admin_user="admin" # Admin username
rabbitmq_admin_password="admin" # Admin password
rabbitmq_write_user="writeonly" # "writeonly" username
rabbitmq_write_password="writeonly" # "writeonly" password
rabbitmq_read_user="readonly" # "readonly" username
rabbitmq_read_password="readonly" # "readonly" password
```

Once these have been set to whatever you wish, you can test the deployment with the following steps:

1) Destroy your environment
2) Check out this branch
3) Checkout the appropriate branch in eq-messaging
4) Open the `message_queue.tf` file and find the "null_resource" "ansible" resource.
5) modify the "ansible-playback" command to load your local copy of ansible
6) Save your changes and run apply
7) SSH into either of the rabbitmq instances and run:

```
sudo rabbitmqctl list_users
```

8) Verify your users have been created

**_Who can test**_

Anybody except @weapdiv-david
