### PR TITLE
Eq 99 automatic deploy submitter

### DIFF
--- a/deploy_submitter.sh
+++ b/deploy_submitter.sh
@@ -3,10 +3,13 @@
 # Must be run remotely on submitter boxes
 
 SUBMITTER_REPO_URL=https://github.com/ONSdigital/eq-submitter
-BRANCH=master
+BRANCH=eq-99-automatic-deploy-submitter
 
 sudo apt-get update
-sudo apt-get install python-pip unzip git -y
+sudo apt-get install python-pip -y
+sudo apt-get install unzip -y
+sudo apt-get install git -y
+
 # Install 3.2.X so we can use ENV_* syntax in our startup script.
 sudo pip install supervisor
 

--- a/deploy_submitter.sh
+++ b/deploy_submitter.sh
@@ -16,6 +16,9 @@ mv eq-submitter-$BRANCH eq-submitter
 cd eq-submitter
 pip install --user -r requirements.txt
 
+# Make sure we've got the correct env variables set
+sudo source /root/env.sh
+
 # Setup init script and restart supervisor
 sudo cp supervisor.sh /etc/init.d/supervisord
 sudo chmod +x /etc/init.d/supervisord

--- a/deploy_submitter.sh
+++ b/deploy_submitter.sh
@@ -3,7 +3,7 @@
 # Must be run remotely on submitter boxes
 
 SUBMITTER_REPO_URL=https://github.com/ONSdigital/eq-submitter
-BRANCH=eq-99-automatic-deploy-submitter
+BRANCH=master
 
 sudo apt-get update
 sudo apt-get install python-pip -y

--- a/deploy_submitter.sh
+++ b/deploy_submitter.sh
@@ -16,9 +16,6 @@ mv eq-submitter-$BRANCH eq-submitter
 cd eq-submitter
 pip install --user -r requirements.txt
 
-# Make sure we've got the correct env variables set
-sudo source /root/env.sh
-
 # Setup init script and restart supervisor
 sudo cp supervisor.sh /etc/init.d/supervisord
 sudo chmod +x /etc/init.d/supervisord

--- a/deploy_submitter.sh
+++ b/deploy_submitter.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Must be run remotely on submitter boxes
+
+SUBMITTER_REPO_URL=https://github.com/ONSdigital/eq-submitter
+BRANCH=EQ-99-pick-up-env-vars
+
+sudo apt-get update
+sudo apt-get install python-pip unzip git -y
+# Install 3.2.X so we can use ENV_* syntax in our startup script.
+sudo pip install supervisor
+
+wget https://github.com/ONSDigital/eq-submitter/archive/$BRANCH.tar.gz
+tar -xvf $BRANCH.tar.gz
+mv eq-submitter-$BRANCH eq-submitter
+cd eq-submitter
+pip install --user -r requirements.txt
+
+# Setup init script and restart supervisor
+sudo cp supervisor.sh /etc/init.d/supervisord
+sudo chmod +x /etc/init.d/supervisord
+sudo update-rc.d supervisord defaults
+
+# Move our config for our program to the supervisord conf file.
+sudo cp supervisord.conf /etc/supervisord.conf
+sudo /etc/init.d/supervisord restart

--- a/deploy_submitter.sh
+++ b/deploy_submitter.sh
@@ -3,7 +3,7 @@
 # Must be run remotely on submitter boxes
 
 SUBMITTER_REPO_URL=https://github.com/ONSdigital/eq-submitter
-BRANCH=EQ-99-pick-up-env-vars
+BRANCH=master
 
 sudo apt-get update
 sudo apt-get install python-pip unzip git -y

--- a/submitter.tf
+++ b/submitter.tf
@@ -2,6 +2,8 @@ resource "template_file" "submitter_user_data" {
     template = "${file("templates/env_ec2_variables_submitter.sh.tpl")}"
 
     vars {
+          rabbitmq_admin_user = "${var.rabbitmq_admin_user}"
+          rabbitmq_admin_password = "${var.rabbitmq_admin_password}"
           rabbitmq_url = "${aws_elb.rabbitmq.dns_name}"
           rabbitmq_queue = "${var.message_queue_name}"
           submissions_bucket_name = "${var.submissions_bucket_name}"

--- a/submitter.tf
+++ b/submitter.tf
@@ -2,7 +2,9 @@ resource "template_file" "submitter_user_data" {
     template = "${file("templates/env_ec2_variables_submitter.sh.tpl")}"
 
     vars {
-          rabbitmq_url = "${aws_elb.rabbitmq.dns_name}"
+          rabbitmq_host = "${aws_elb.rabbitmq.dns_name}"
+          rabbitmq_user = "${var.rabbitmq_read_user}"
+          rabbitmq_pass = "${var.rabbitmq_read_password}"
           rabbitmq_queue = "${var.message_queue_name}"
           submissions_bucket_name = "${var.submissions_bucket_name}"
           # These are only for the submitter use

--- a/submitter.tf
+++ b/submitter.tf
@@ -15,14 +15,23 @@ resource "template_file" "submitter_user_data" {
 resource "aws_instance" "submitter" {
     ami = "ami-47a23a30"
     count = 2
-    instance_type = "t2.small"
+    instance_type = "t2.medium"
     key_name = "${var.aws_key_pair}"
     subnet_id = "${aws_subnet.default.id}"
     associate_public_ip_address = true
     security_groups = ["${aws_security_group.default.id}"]
     user_data = "${template_file.submitter_user_data.rendered}"
 
+
     tags {
       Name = "Submitter ${var.env} ${count.index + 1}"
+    }
+
+    provisioner "remote-exec" {
+        connection {
+            user = "ubuntu"
+            private_key = "${var.aws_key_pair}.pem"
+        }
+        script = "deploy_submitter.sh"
     }
 }

--- a/templates/env_ec2_variables_submitter.sh.tpl
+++ b/templates/env_ec2_variables_submitter.sh.tpl
@@ -13,3 +13,5 @@ export AWS_SECRET_ACCESS_KEY=${aws_secret_access_key}
 EOF
 chmod +x $ENV_FILE
 . $ENV_FILE
+
+cat $ENV_FILE >> /etc/environment

--- a/templates/env_ec2_variables_submitter.sh.tpl
+++ b/templates/env_ec2_variables_submitter.sh.tpl
@@ -5,7 +5,7 @@ echo "In the userdata script"
 mkdir -p `dirname $ENV_FILE`
 cat << EOF > $ENV_FILE
 #! /bin/bash
-export EQ_RABBITMQ_URL=${rabbitmq_url}                          # The URL to the RabbitMQ Load Balancer
+export EQ_RABBITMQ_URL=amqp://${rabbitmq_url}                          # The URL to the RabbitMQ Load Balancer
 export EQ_RABBITMQ_QUEUE_NAME=${rabbitmq_queue}                 # The name of the queue
 export EQ_SUBMISSIONS_BUCKET_NAME=${submissions_bucket_name}    # The name of the S3 Bucket
 export AWS_ACCESS_KEY=${aws_access_key}
@@ -15,3 +15,4 @@ chmod +x $ENV_FILE
 . $ENV_FILE
 
 cat $ENV_FILE >> /etc/environment
+./$ENV_FILE

--- a/templates/env_ec2_variables_submitter.sh.tpl
+++ b/templates/env_ec2_variables_submitter.sh.tpl
@@ -5,7 +5,7 @@ echo "In the userdata script"
 mkdir -p `dirname $ENV_FILE`
 cat << EOF > $ENV_FILE
 #! /bin/bash
-export EQ_RABBITMQ_URL=amqp://${rabbitmq_url}                          # The URL to the RabbitMQ Load Balancer
+export EQ_RABBITMQ_URL=amqp://${rabbitmq_admin_user}:${rabbitmq_admin_password}@${rabbitmq_url}:5672/%2F                          # The URL to the RabbitMQ Load Balancer
 export EQ_RABBITMQ_QUEUE_NAME=${rabbitmq_queue}                 # The name of the queue
 export EQ_SUBMISSIONS_BUCKET_NAME=${submissions_bucket_name}    # The name of the S3 Bucket
 export AWS_ACCESS_KEY=${aws_access_key}

--- a/templates/env_ec2_variables_submitter.sh.tpl
+++ b/templates/env_ec2_variables_submitter.sh.tpl
@@ -1,18 +1,20 @@
 #! /bin/bash
-set -x
-ENV_FILE=/root/env.sh
-echo "In the userdata script"
-mkdir -p `dirname $ENV_FILE`
-cat << EOF > $ENV_FILE
-#! /bin/bash
-export EQ_RABBITMQ_URL=amqp://${rabbitmq_url}                          # The URL to the RabbitMQ Load Balancer
+set -x -e
+
+# create a launcher script for the submitter
+cat << EOF >> /usr/local/bin/run_submitter.sh
+#!/bin/bash
+export EQ_RABBITMQ_URL=amqp://${rabbitmq_user}:${rabbitmq_pass}@${rabbitmq_host}                   # The URL to the RabbitMQ Load Balancer
 export EQ_RABBITMQ_QUEUE_NAME=${rabbitmq_queue}                 # The name of the queue
 export EQ_SUBMISSIONS_BUCKET_NAME=${submissions_bucket_name}    # The name of the S3 Bucket
 export AWS_ACCESS_KEY=${aws_access_key}
 export AWS_SECRET_ACCESS_KEY=${aws_secret_access_key}
-EOF
-chmod +x $ENV_FILE
-. $ENV_FILE
 
-cat $ENV_FILE >> /etc/environment
-./$ENV_FILE
+/usr/bin/python /home/ubuntu/eq-submitter/application.py
+EOF
+
+# make our launcher executable
+chmod +x /usr/local/bin/run_submitter.sh
+
+# create a file to let observers know this script has run
+touch /tmp/user-data-ran


### PR DESCRIPTION
**What**

Given the changes to eq-submitter, this PR is the final piece in automating this release's architecture, creating supervisord processes to run the daemon created in eq-submitter, binding the submitter into the rabbitmq queues, listening and awaiting encrypted survey responses.

**How to test**
1. Checkout this branch 
2. Create a new environment using terraform apply
3. SSH into the submitter boxes created and check that supervisord is running and that the submitter is connecting to the rabbitmq queues via the ELB

**Who can test** 

Anyone but @dhilton
