### PR TITLE
Fix elasticbeanstalkdeploy no keymat

### DIFF
--- a/deploy_surveyrunner.sh
+++ b/deploy_surveyrunner.sh
@@ -27,4 +27,7 @@ echo "*****************************************************"
 # We can't seem to pass in that we DON'T want SSH keys. Urgh.
 eb init -i -r eu-west-1 -p "Python 3.4" $1 <<<n
 npm install && npm run compile
+# While we await Vault implemetation for KEYMAT handling.
+# We place JWT behind a feature flag
+eb setenv EQ_PRODUCTION=false
 eb deploy $2


### PR DESCRIPTION
**What**

A collection of issues has occurred after the merging of the JWT work and the final hooking up of the RabbitMQ based submitter. This has been blocked by our lack of a solution to handling keymat (private and public keys) Thus this PR puts that functionality behind a developer friendly feature flag to enable our terraform applies to create a working environment.

**How to test**
1. Once https://github.com/ONSdigital/eq-terraform/pull/5 has merged, rebase this branch and clone locally.
2. Create a brand new environment 
3. Check that the healthcheck returns ok for all parts given.

**Who can test**

Anyone but @dhilton 
