### PR TITLE
FIX: Add correct setting of Git ref as environment variable

### DIFF
--- a/deploy_surveyrunner.sh
+++ b/deploy_surveyrunner.sh
@@ -26,8 +26,10 @@ echo "*****************************************************"
 
 # We can't seem to pass in that we DON'T want SSH keys. Urgh.
 eb init -i -r eu-west-1 -p "Python 3.4" $1 <<<n
-npm install && npm run compile
+npm set progress=false && npm install && npm run compile
 # While we await Vault implemetation for KEYMAT handling.
 # We place JWT behind a feature flag
 eb setenv EQ_PRODUCTION=false
+git_ref=$(git rev-parse HEAD)
+eb setenv EQ_GIT_REF=$git_ref
 eb deploy $2


### PR DESCRIPTION
**What**

Somehow I missed adding the setting of the git ref of head as part of the work on improving our healthcheck.
This commit fixes it and removes the NPM install progress bar to speed up deployments.

**How to test**
1. Checkout this branch
2. Create a new environment _Or_ taint just your elasticbeanstalk instance and rerun apply
3. Check that the healthcheck on your surveyrunner instance has the correct git ref as given 
   by local command `git rev-parse HEAD`

**Who can test**

Anyone but @dhilton
