### PR TITLE
Fixing broken syntax

### DIFF
--- a/smoke_test.tf
+++ b/smoke_test.tf
@@ -8,4 +8,4 @@ resource "null_resource" "smoke_test" {
     provisioner "local-exec" {
       command = "rm -rf tmp"
     }
-
+}


### PR DESCRIPTION
Missing { at end of file is causing the production jenkins job to fail
