### PR TITLE
Add logging support

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -76,3 +76,8 @@ variable "rabbitmq_write_user" {
 variable "rabbitmq_write_password" {
   description = "The 'write-only' user password for rabbitmq"
 }
+
+variable "eq_sr_log_level" {
+  description = "The Survey Runner logging level (One of ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'])"
+  default     = "WARNING"
+}

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -48,7 +48,7 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_LOG_LEVEL"
-    value     = "WARNING"
+    value     = "${var.eq_sr_log_level}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -47,11 +47,6 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "ENV_NAME"
-    value     = "${var.env}"
-  }
-  setting {
-    namespace = "aws:elasticbeanstalk:application:environment"
     name      = "AWS_ACCESS_KEY_ID"
     value     = "${var.aws_access_key}"
   }

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -42,9 +42,30 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
   }
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
-    name      = "InstanceType"
-    value     = "t2.small"
+    name = "InstanceType"
+    value = "t2.small"
   }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "ENV_NAME"
+    value     = "${var.env}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "AWS_ACCESS_KEY_ID"
+    value     = "${var.aws_access_key}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "AWS_SECRET_ACCESS_KEY"
+    value     = "${var.aws_secret_key}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "AWS_DEFAULT_REGION"
+    value     = "${var.aws_default_region}"
+  }
+
   # Extra settings still to implement
   # EQ_RRM_PUBLIC_KEY = os.getenv('EQ_RRM_PUBLIC_KEY', './jwt-test-keys/rrm-public.pem')
   # EQ_SR_PRIVATE_KEY = os.getenv('EQ_SR_PRIVATE_KEY', './jwt-test-keys/sr-private.pem')
@@ -61,4 +82,8 @@ resource "aws_route53_record" "survey_runner" {
   type = "CNAME"
   ttl = "60"
   records = ["${aws_elastic_beanstalk_environment.sr_prime.cname}"]
+}
+
+resource "aws_cloudwatch_log_group" "survey_runner" {
+  name = "${var.env}-surveyrunner"
 }

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -65,7 +65,6 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
     name      = "AWS_DEFAULT_REGION"
     value     = "${var.aws_default_region}"
   }
-
   # Extra settings still to implement
   # EQ_RRM_PUBLIC_KEY = os.getenv('EQ_RRM_PUBLIC_KEY', './jwt-test-keys/rrm-public.pem')
   # EQ_SR_PRIVATE_KEY = os.getenv('EQ_SR_PRIVATE_KEY', './jwt-test-keys/sr-private.pem')

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -50,6 +50,11 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
     name      = "EQ_LOG_LEVEL"
     value     = "${var.eq_sr_log_level}"
   }
+   setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "EQ_SR_LOG_GROUP"
+    value     = "${aws_cloudwatch_log_group.survey_runner.name}"
+  }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "AWS_ACCESS_KEY_ID"

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -47,6 +47,11 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "EQ_LOG_LEVEL"
+    value     = "WARNING"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
     name      = "AWS_ACCESS_KEY_ID"
     value     = "${var.aws_access_key}"
   }


### PR DESCRIPTION
**_What**_

Adds support for cloudwatch logs to survey-runner

**_How to test**_

1) Ensure that `deploy_surveyrunner.sh` is pointing at the `add-logging-support` branch of eq-survey-runner
2) Run terraform and spin up your environment
3) Access the survey runner application 
4) Access Cludwatch logs for your environment and click on the `watchtower` log group.  It may take a minute or so for the logs to appear.

**_Who can test**_

Anybody except @weapdiv-david
