### PR TITLE
Make all AWS instance types configurable

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -81,3 +81,18 @@ variable "eq_sr_log_level" {
   description = "The Survey Runner logging level (One of ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'])"
   default     = "WARNING"
 }
+
+variable "eb_instance_type" {
+  description = "Elastic Beanstalk Instance Type"
+  default     = "t2.small"
+}
+
+variable "submitter_instance_type" {
+  description = "Submitter Instance Type"
+  default     = "t2.small"
+}
+
+variable "rabbitmq_instance_type" {
+  description = "Rabbit MQ Instance type"
+  default     = "t2.small"
+}

--- a/message_queue.tf
+++ b/message_queue.tf
@@ -1,7 +1,7 @@
 resource "aws_instance" "rabbitmq" {
     ami = "ami-47a23a30"
     count = 2
-    instance_type = "t2.small"
+    instance_type = "${var.rabbitmq_instance_type}"
     key_name = "${var.aws_key_pair}"
     subnet_id = "${aws_subnet.default.id}"
     associate_public_ip_address = true

--- a/submitter.tf
+++ b/submitter.tf
@@ -17,7 +17,7 @@ resource "template_file" "submitter_user_data" {
 resource "aws_instance" "submitter" {
     ami = "ami-47a23a30"
     count = 2
-    instance_type = "t2.medium"
+    instance_type = "${var.submitter_instance_type}"
     key_name = "${var.aws_key_pair}"
     subnet_id = "${aws_subnet.default.id}"
     associate_public_ip_address = true

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -42,8 +42,8 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
   }
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
-    name = "InstanceType"
-    value = "t2.small"
+    name      = "InstanceType"
+    value     = "${var.eb_instance_type}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"


### PR DESCRIPTION
**What**
Allow the AWS instance types to be configurable via terraform variables.

**How to test**
1. Check out this branch
2. Run terraform apply
3. Check the health check.

**Who can review**
Anyone apart from @warrenbailey
