### PR TITLE
eq-13 infrastucture monitoring, add 8 alerts

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,5 +1,5 @@
-resource "aws_cloudwatch_metric_alarm" "Rabbitmq1CPU" {
-    alarm_name = "${var.env}-Rabbitmq 1 CPU alert"
+resource "aws_cloudwatch_metric_alarm" "rabbitmq1_cpu" {
+    alarm_name = "${var.env}-rabbitmq1-cpu-alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "CPUUtilization"
@@ -12,8 +12,8 @@ resource "aws_cloudwatch_metric_alarm" "Rabbitmq1CPU" {
     dimensions { "InstanceId"="${aws_instance.rabbitmq.0.id}"}
 }
 
-resource "aws_cloudwatch_metric_alarm" "Rabbitmq2CPU" {
-    alarm_name = "${var.env}-Rabbitmq 2 CPU alert"
+resource "aws_cloudwatch_metric_alarm" "rabbitmq2_cpu" {
+    alarm_name = "${var.env}-rabbitmq2-cpu-alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "CPUUtilization"
@@ -27,8 +27,8 @@ resource "aws_cloudwatch_metric_alarm" "Rabbitmq2CPU" {
 }
 
 
-resource "aws_cloudwatch_metric_alarm" "Submitter1CPU" {
-    alarm_name = "${var.env}-Submitter 1 CPU alert"
+resource "aws_cloudwatch_metric_alarm" "submitter1_cpu" {
+    alarm_name = "${var.env}-submitter1-cpu-alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "CPUUtilization"
@@ -41,8 +41,8 @@ resource "aws_cloudwatch_metric_alarm" "Submitter1CPU" {
     dimensions { "InstanceId"="${aws_instance.submitter.0.id}"}
 }
 
-resource "aws_cloudwatch_metric_alarm" "Submitter2CPU" {
-    alarm_name = "${var.env}-Submitter 2 CPU alert"
+resource "aws_cloudwatch_metric_alarm" "submitter2_cpu" {
+    alarm_name = "${var.env}-submitter2-cpu-alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "CPUUtilization"
@@ -56,8 +56,8 @@ resource "aws_cloudwatch_metric_alarm" "Submitter2CPU" {
 }
 
 
-resource "aws_cloudwatch_metric_alarm" "Rabbitmq1Status" {
-    alarm_name = "${var.env}-Rabbitmq 1 Status alert"
+resource "aws_cloudwatch_metric_alarm" "rabbitmq1_status" {
+    alarm_name = "${var.env}-rabbitmq-1-status-alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "StatusCheckFailed"
@@ -70,8 +70,8 @@ resource "aws_cloudwatch_metric_alarm" "Rabbitmq1Status" {
     dimensions { "InstanceId"="${aws_instance.rabbitmq.0.id}"}
 }
 
-resource "aws_cloudwatch_metric_alarm" "Rabbitmq2Status" {
-    alarm_name = "${var.env}-Rabbitmq 2 Status alert"
+resource "aws_cloudwatch_metric_alarm" "rabbitmq2_status" {
+    alarm_name = "${var.env}-rabbitmq2-status-alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "StatusCheckFailed"
@@ -85,8 +85,8 @@ resource "aws_cloudwatch_metric_alarm" "Rabbitmq2Status" {
 }
 
 
-resource "aws_cloudwatch_metric_alarm" "Submitter1Status" {
-    alarm_name = "${var.env}-Submitter 1 Status alert"
+resource "aws_cloudwatch_metric_alarm" "submitter1_status" {
+    alarm_name = "${var.env}-submitter1-status-alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "StatusCheckFailed"
@@ -99,8 +99,8 @@ resource "aws_cloudwatch_metric_alarm" "Submitter1Status" {
     dimensions { "InstanceId"="${aws_instance.submitter.0.id}"}
 }
 
-resource "aws_cloudwatch_metric_alarm" "Submitter2Status" {
-    alarm_name = "${var.env}-Submitter 2 Status alert"
+resource "aws_cloudwatch_metric_alarm" "submitter2_status" {
+    alarm_name = "${var.env}-submitter2-status-alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "StatusCheckFailed"

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "Rabbitmq1CPU" {
-    alarm_name = "Rabbitmq 1 CPU alert"
+    alarm_name = "${var.env}-Rabbitmq 1 CPU alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "CPUUtilization"
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_metric_alarm" "Rabbitmq1CPU" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "Rabbitmq2CPU" {
-    alarm_name = "Rabbitmq 2 CPU alert"
+    alarm_name = "${var.env}-Rabbitmq 2 CPU alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "CPUUtilization"
@@ -28,7 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "Rabbitmq2CPU" {
 
 
 resource "aws_cloudwatch_metric_alarm" "Submitter1CPU" {
-    alarm_name = "Submitter 1 CPU alert"
+    alarm_name = "${var.env}-Submitter 1 CPU alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "CPUUtilization"
@@ -42,7 +42,7 @@ resource "aws_cloudwatch_metric_alarm" "Submitter1CPU" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "Submitter2CPU" {
-    alarm_name = "Submitter 2 CPU alert"
+    alarm_name = "${var.env}-Submitter 2 CPU alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "CPUUtilization"
@@ -57,7 +57,7 @@ resource "aws_cloudwatch_metric_alarm" "Submitter2CPU" {
 
 
 resource "aws_cloudwatch_metric_alarm" "Rabbitmq1Status" {
-    alarm_name = "Rabbitmq 1 Status alert"
+    alarm_name = "${var.env}-Rabbitmq 1 Status alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "StatusCheckFailed"
@@ -71,7 +71,7 @@ resource "aws_cloudwatch_metric_alarm" "Rabbitmq1Status" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "Rabbitmq2Status" {
-    alarm_name = "Rabbitmq 2 Status alert"
+    alarm_name = "${var.env}-Rabbitmq 2 Status alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "StatusCheckFailed"
@@ -86,7 +86,7 @@ resource "aws_cloudwatch_metric_alarm" "Rabbitmq2Status" {
 
 
 resource "aws_cloudwatch_metric_alarm" "Submitter1Status" {
-    alarm_name = "Submitter 1 Status alert"
+    alarm_name = "${var.env}-Submitter 1 Status alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "StatusCheckFailed"
@@ -100,7 +100,7 @@ resource "aws_cloudwatch_metric_alarm" "Submitter1Status" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "Submitter2Status" {
-    alarm_name = "Submitter 2 Status alert"
+    alarm_name = "${var.env}-Submitter 2 Status alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "StatusCheckFailed"
@@ -112,3 +112,11 @@ resource "aws_cloudwatch_metric_alarm" "Submitter2Status" {
     alarm_actions = ["${var.cloudwatch_alarm_arn}"]
     dimensions { "InstanceId"="${aws_instance.submitter.1.id}"}
 }
+
+
+
+
+
+
+
+

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,0 +1,114 @@
+resource "aws_cloudwatch_metric_alarm" "Rabbitmq1CPU" {
+    alarm_name = "Rabbitmq 1 CPU alert"
+    evaluation_periods = "1"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    metric_name = "CPUUtilization"
+    namespace ="AWS/EC2"
+    period ="300"
+    statistic ="Average"
+    threshold ="80"
+    alarm_description = "Alert generated if over 80% CPU usage"
+    alarm_actions = ["${var.cloudwatch_alarm_arn}"]
+    dimensions { "InstanceId"="${aws_instance.rabbitmq.0.id}"}
+}
+
+resource "aws_cloudwatch_metric_alarm" "Rabbitmq2CPU" {
+    alarm_name = "Rabbitmq 2 CPU alert"
+    evaluation_periods = "1"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    metric_name = "CPUUtilization"
+    namespace ="AWS/EC2"
+    period ="300"
+    statistic ="Average"
+    threshold ="80"
+    alarm_description = "Alert generated if over 80% CPU usage"
+    alarm_actions = ["${var.cloudwatch_alarm_arn}"]
+    dimensions { "InstanceId"="${aws_instance.rabbitmq.1.id}"}
+}
+
+
+resource "aws_cloudwatch_metric_alarm" "Submitter1CPU" {
+    alarm_name = "Submitter 1 CPU alert"
+    evaluation_periods = "1"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    metric_name = "CPUUtilization"
+    namespace ="AWS/EC2"
+    period ="300"
+    statistic ="Average"
+    threshold ="80"
+    alarm_description = "Alert generated if over 80% CPU usage"
+    alarm_actions = ["${var.cloudwatch_alarm_arn}"]
+    dimensions { "InstanceId"="${aws_instance.submitter.0.id}"}
+}
+
+resource "aws_cloudwatch_metric_alarm" "Submitter2CPU" {
+    alarm_name = "Submitter 2 CPU alert"
+    evaluation_periods = "1"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    metric_name = "CPUUtilization"
+    namespace ="AWS/EC2"
+    period ="300"
+    statistic ="Average"
+    threshold ="80"
+    alarm_description = "Alert generated if over 80% CPU usage"
+    alarm_actions = ["${var.cloudwatch_alarm_arn}"]
+    dimensions { "InstanceId"="${aws_instance.submitter.1.id}"}
+}
+
+
+resource "aws_cloudwatch_metric_alarm" "Rabbitmq1Status" {
+    alarm_name = "Rabbitmq 1 Status alert"
+    evaluation_periods = "1"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    metric_name = "StatusCheckFailed"
+    namespace ="AWS/EC2"
+    period ="300"
+    statistic ="Maximum"
+    threshold ="1"
+    alarm_description = "Alert generated if status changes to failure"
+    alarm_actions = ["${var.cloudwatch_alarm_arn}"]
+    dimensions { "InstanceId"="${aws_instance.rabbitmq.0.id}"}
+}
+
+resource "aws_cloudwatch_metric_alarm" "Rabbitmq2Status" {
+    alarm_name = "Rabbitmq 2 Status alert"
+    evaluation_periods = "1"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    metric_name = "StatusCheckFailed"
+    namespace ="AWS/EC2"
+    period ="300"
+    statistic ="Maximum"
+    threshold ="1"
+    alarm_description = "Alert generated if status changes to failure"
+    alarm_actions = ["${var.cloudwatch_alarm_arn}"]
+    dimensions { "InstanceId"="${aws_instance.rabbitmq.1.id}"}
+}
+
+
+resource "aws_cloudwatch_metric_alarm" "Submitter1Status" {
+    alarm_name = "Submitter 1 Status alert"
+    evaluation_periods = "1"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    metric_name = "StatusCheckFailed"
+    namespace ="AWS/EC2"
+    period ="300"
+    statistic ="Maximum"
+    threshold ="1"
+    alarm_description = "Alert generated if status changes to failure"
+    alarm_actions = ["${var.cloudwatch_alarm_arn}"]
+    dimensions { "InstanceId"="${aws_instance.submitter.0.id}"}
+}
+
+resource "aws_cloudwatch_metric_alarm" "Submitter2Status" {
+    alarm_name = "Submitter 2 Status alert"
+    evaluation_periods = "1"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    metric_name = "StatusCheckFailed"
+    namespace ="AWS/EC2"
+    period ="300"
+    statistic ="Maximum"
+    threshold ="1"
+    alarm_description = "Alert generated if status changes to failure"
+    alarm_actions = ["${var.cloudwatch_alarm_arn}"]
+    dimensions { "InstanceId"="${aws_instance.submitter.1.id}"}
+}

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -94,10 +94,10 @@ variable "submitter_instance_type" {
 
 variable "rabbitmq_instance_type" {
   description = "Rabbit MQ Instance type"
-  default     = "t2.small"
+  default = "t2.small"
+}
 
 variable "cloudwatch_alarm_arn" {
   description = "arn for cloudwatch"
   default = "arn:aws:sns:eu-west-1:229460966734:eq-alert"
-
 }

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -95,4 +95,9 @@ variable "submitter_instance_type" {
 variable "rabbitmq_instance_type" {
   description = "Rabbit MQ Instance type"
   default     = "t2.small"
+
+variable "cloudwatch_alarm_arn" {
+  description = "arn for cloudwatch"
+  default = "arn:aws:sns:eu-west-1:229460966734:eq-alert"
+
 }


### PR DESCRIPTION
**What**
Adding 8 alerts to Cloudwatch for rabbitmq1, rabbitmq2, submitter1, submitter2 to monitor CPU usage and Status failure in each. Failures being published to the Slack Development channel

**How to test**
1. Review the new script and SNS configurations in Lambda called Slack
2. Run terraform
3. Check each EC2 instance has 2 alerts associated with them. This can also be done in the Cloudwatch section of AWS  or EC2 console (Give them a couple of minutes as initial metrics must be collected for them to work and they will appear as insufficient data to begin with)
4. Open up the alert and change the threshold to trigger the alarm
5. Check a message has appeared in slack and is correct

**Who can test**
Anyone but @LJBabbage
