### PR TITLE
Change to internal VPC IP range

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -101,3 +101,8 @@ variable "cloudwatch_alarm_arn" {
   description = "arn for cloudwatch"
   default = "arn:aws:sns:eu-west-1:229460966734:eq-alert"
 }
+
+variable "vpc_ip_block" {
+  description = "VPC internal IP cidr block for ec2 machines"
+  default = "10.30.20.0/24"
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,6 +1,6 @@
 # Create a VPC to launch our instances into
 resource "aws_vpc" "default" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = "${var.vpc_ip_block}"
   enable_dns_support = true
   tags {
     Name = "${var.env}-vpc"
@@ -22,7 +22,7 @@ resource "aws_route" "internet_access" {
 # Create a subnet to launch our ec2 instances and ElasticBeanstalk into
 resource "aws_subnet" "default" {
   vpc_id                  = "${aws_vpc.default.id}"
-  cidr_block              = "10.0.1.0/24"
+  cidr_block              = "${var.vpc_ip_block}"
   map_public_ip_on_launch = true
 }
 
@@ -47,7 +47,7 @@ resource "aws_security_group" "default" {
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
-    cidr_blocks = ["10.0.0.0/16"]
+    cidr_blocks = ["${var.vpc_ip_block}"]
   }
 
   # Rabbitmq
@@ -56,50 +56,50 @@ resource "aws_security_group" "default" {
     from_port = 4369
     to_port   = 4369
     protocol  = "tcp"
-    cidr_blocks = ["10.0.0.0/16"]
+    cidr_blocks = ["${var.vpc_ip_block}"]
   }
   egress {
     from_port = 4369
     to_port   = 4369
     protocol  = "tcp"
-    cidr_blocks = ["10.0.0.0/16"]
+    cidr_blocks = ["${var.vpc_ip_block}"]
   }
   ingress {
     from_port = 25672
     to_port   = 25672
     protocol  = "tcp"
-    cidr_blocks = ["10.0.0.0/16"]
+    cidr_blocks = ["${var.vpc_ip_block}"]
   }
   egress {
     from_port = 25672
     to_port   = 25672
     protocol  = "tcp"
-    cidr_blocks = ["10.0.0.0/16"]
+    cidr_blocks = ["${var.vpc_ip_block}"]
   }
   ## AMQP Connection ports
   ingress {
     from_port = 5672
     to_port   = 5672
     protocol  = "tcp"
-    cidr_blocks = ["10.0.0.0/16"]
+    cidr_blocks = ["${var.vpc_ip_block}"]
   }
   egress {
     from_port = 5672
     to_port   = 5672
     protocol  = "tcp"
-    cidr_blocks = ["10.0.0.0/16"]
+    cidr_blocks = ["${var.vpc_ip_block}"]
   }
   ingress {
     from_port = 5671
     to_port   = 5671
     protocol  = "tcp"
-    cidr_blocks = ["10.0.0.0/16"]
+    cidr_blocks = ["${var.vpc_ip_block}"]
   }
   egress {
     from_port = 5671
     to_port   = 5671
     protocol  = "tcp"
-    cidr_blocks = ["10.0.0.0/16"]
+    cidr_blocks = ["${var.vpc_ip_block}"]
   }
   # End RabbitMQ ports
 


### PR DESCRIPTION
**What**

This PR changes the VPC internal IP range to align with the ONS.
This enables us to connnect a VPN connection back into the ONS estate.

**How to test**
1. Check out this branch
2. Run terraform apply using the custom elasticbeanstalk supported branch
3. Check via the AWS console that the ip addresses of all ec2 machines lie inside the cidr of `10.30.20.0/24` use a cidr calculator if in doubt.

**Who can test**

Anyone but @dhilton
