### PR TITLE
Add static IP's for rabbitmq servers

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -106,3 +106,13 @@ variable "vpc_ip_block" {
   description = "VPC internal IP cidr block for ec2 machines"
   default = "10.30.20.0/24"
 }
+
+variable "rabbitmq_ip_prime" {
+  description = "Static IP of prime rabbitmq server"
+  default =  "10.30.20.15"
+}
+
+variable "rabbitmq_ip_failover" {
+  description = "Static IP of secondary failover rabbitmq server"
+  default = "10.30.20.16"
+}

--- a/message_queue.tf
+++ b/message_queue.tf
@@ -12,6 +12,30 @@ resource "aws_instance" "rabbitmq" {
     }
 }
 
+# Static Network interfaces for the two RabbitMq boxes
+# Prime IP
+resource "aws_network_interface" "ons_vpn_prime" {
+    subnet_id = "${aws_subnet.default.id}"
+    private_ips = ["${var.rabbitmq_ip_prime}"]
+    security_groups = ["${aws_security_group.default.id}"]
+    attachment {
+        instance = "${aws_instance.rabbitmq.0.id}"
+        device_index = 1
+    }
+}
+
+# Failover IP
+resource "aws_network_interface" "ons_vpn_failover" {
+    subnet_id = "${aws_subnet.default.id}"
+    private_ips = ["${var.rabbitmq_ip_failover}"]
+    security_groups = ["${aws_security_group.default.id}"]
+    attachment {
+        instance = "${aws_instance.rabbitmq.1.id}"
+        device_index = 1
+    }
+}
+
+
 resource "aws_elb" "rabbitmq" {
   name = "${var.env}-rabbitmq-elb"
   subnets = ["${aws_subnet.default.id}"]


### PR DESCRIPTION
**what**

To enable the VPN to route traffic to rabbitmq in our VPC, we need to create static IP's for these machines.

This commit adds two new network interfaces and assigns them each a static IP for the purposes of routing traffic.

**How to test**
1. Check out this branch
2. Create a new environment using this branch
3. Check that each of the rabbitmq servers have a second interface with IP's matching x.x.x.15 or x.x.x.16 

**Who can test**
Anyone but @dhilton
