### PR TITLE
Remove unused allow all security group

### DIFF
--- a/message_queue.tf
+++ b/message_queue.tf
@@ -185,26 +185,3 @@ resource "aws_route53_record" "rabbitmq2" {
   ttl = "60"
   records = ["${aws_instance.rabbitmq.1.public_ip}"]
 }
-
-resource "aws_security_group" "allow_all" {
-  name = "${var.env}-allow_all"
-  description = "Allow all inbound traffic"
-
-    ingress {
-      from_port = 0
-      to_port = 0
-      protocol = "-1"
-      cidr_blocks = ["0.0.0.0/0"]
-    }
-
-    egress {
-      from_port = 0
-      to_port = 0
-      protocol = "-1"
-      cidr_blocks = ["0.0.0.0/0"]
-    }
-
-    tags {
-        Name = "Terraform Allow All"
-    }
-}

--- a/vpc.tf
+++ b/vpc.tf
@@ -20,9 +20,6 @@ resource "aws_route" "internet_access" {
   route_table_id         = "${aws_vpc.default.main_route_table_id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.default.id}"
-  tags {
-    Name = "${var.env}-net-access"
-  }
 }
 
 # Create a subnet to launch our ec2 instances and ElasticBeanstalk into

--- a/vpc.tf
+++ b/vpc.tf
@@ -10,6 +10,9 @@ resource "aws_vpc" "default" {
 # Create an internet gateway to give our subnet access to the outside world
 resource "aws_internet_gateway" "default" {
   vpc_id = "${aws_vpc.default.id}"
+  tags {
+    Name = "${var.env}-igateway"
+  }
 }
 
 # Grant the VPC internet access on its main route table
@@ -17,6 +20,9 @@ resource "aws_route" "internet_access" {
   route_table_id         = "${aws_vpc.default.main_route_table_id}"
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.default.id}"
+  tags {
+    Name = "${var.env}-net-access"
+  }
 }
 
 # Create a subnet to launch our ec2 instances and ElasticBeanstalk into
@@ -24,6 +30,9 @@ resource "aws_subnet" "default" {
   vpc_id                  = "${aws_vpc.default.id}"
   cidr_block              = "${var.vpc_ip_block}"
   map_public_ip_on_launch = true
+  tags {
+    Name = "${var.env}-default-subnet"
+  }
 }
 
 
@@ -31,7 +40,7 @@ resource "aws_subnet" "default" {
 # the instances over SSH and HTTP
 resource "aws_security_group" "default" {
   name        = "survey_runner"
-  description = "Used for "
+  description = "Used for eQ"
   vpc_id      = "${aws_vpc.default.id}"
 
   # SSH access from anywhere


### PR DESCRIPTION
**What**

After a review with @collisdigital we found an unused security group that could lead to confusion about the intended security design of our VPC. It was never attached to an instance nor component but none the less should be removed.

**How to test**
1. Check out this branch
2. Apply this terraform plan and check that a security group called `allow-all` isn't created in your vpc.

**Who can test**

Anyone but @dhilton
