### PR TITLE
Restrict SSH access and document higher security

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ For the smoke test you will need
 
 ## Additional security
 
-To increase the security of the system, remove via the AWS console the public IP's
-of the rabbitmq machines and their SSH access. This is retained to allow provisioning
+To increase the security of the system, remove the security group `"provision-allow-ssh-REMOVE`
+from the rabbitmq machines to block their SSH access. This is retained to allow provisioning
 via ansible. In future we may migrate to a bastion machine to provision, which could
-be then replicated locally via docker / VM bastion. 
+be then replicated locally via docker / VM bastion.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ For the smoke test you will need
 2. Gem 2.5.2 (gem update --system '2.5.2')
 3. Bundle should be 1.10.6 (gem install bundler -v 1.10.6)
 
+## Additional security
+
+To increase the security of the system, remove via the AWS console the public IP's
+of the rabbitmq machines and their SSH access. This is retained to allow provisioning
+via ansible. In future we may migrate to a bastion machine to provision, which could
+be then replicated locally via docker / VM bastion. 
+
 ## Troubleshooting
 
 1. If your build fails make sure the tmp directory has been deleted.

--- a/message_queue.tf
+++ b/message_queue.tf
@@ -1,5 +1,6 @@
 resource "aws_security_group" "provision-allow-ssh-REMOVE" {
   name = "${var.env}-provision-ssh-remove"
+  vpc_id      = "${aws_vpc.default.id}"
 
   # SSH access from anywhere.
   # REMOVE in production via AWS console.

--- a/message_queue.tf
+++ b/message_queue.tf
@@ -1,3 +1,95 @@
+resource "aws_security_group" "provision-allow-ssh-REMOVE" {
+  name = "${var.env}-provision-ssh-remove"
+
+  # SSH access from anywhere.
+  # REMOVE in production via AWS console.
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    }
+}
+
+
+resource "aws_security_group" "rabbit_required" {
+  name        = "${var.env}-RabbitMQ-required"
+  description = "Required for rabbitmq operation"
+  vpc_id      = "${aws_vpc.default.id}"
+
+
+  # HTTP access from the VPC
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["${var.vpc_ip_block}"]
+  }
+
+  # Rabbitmq
+  ## Clustering ports
+  ingress {
+    from_port = 4369
+    to_port   = 4369
+    protocol  = "tcp"
+    cidr_blocks = ["${var.vpc_ip_block}"]
+  }
+  egress {
+    from_port = 4369
+    to_port   = 4369
+    protocol  = "tcp"
+    cidr_blocks = ["${var.vpc_ip_block}"]
+  }
+  ingress {
+    from_port = 25672
+    to_port   = 25672
+    protocol  = "tcp"
+    cidr_blocks = ["${var.vpc_ip_block}"]
+  }
+  egress {
+    from_port = 25672
+    to_port   = 25672
+    protocol  = "tcp"
+    cidr_blocks = ["${var.vpc_ip_block}"]
+  }
+  ## AMQP Connection ports
+  ingress {
+    from_port = 5672
+    to_port   = 5672
+    protocol  = "tcp"
+    cidr_blocks = ["${var.vpc_ip_block}"]
+  }
+  egress {
+    from_port = 5672
+    to_port   = 5672
+    protocol  = "tcp"
+    cidr_blocks = ["${var.vpc_ip_block}"]
+  }
+  ingress {
+    from_port = 5671
+    to_port   = 5671
+    protocol  = "tcp"
+    cidr_blocks = ["${var.vpc_ip_block}"]
+  }
+  egress {
+    from_port = 5671
+    to_port   = 5671
+    protocol  = "tcp"
+    cidr_blocks = ["${var.vpc_ip_block}"]
+  }
+  # End RabbitMQ ports
+
+  # outbound internet access
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+
+
 resource "aws_instance" "rabbitmq" {
     ami = "ami-47a23a30"
     count = 2
@@ -5,7 +97,7 @@ resource "aws_instance" "rabbitmq" {
     key_name = "${var.aws_key_pair}"
     subnet_id = "${aws_subnet.default.id}"
     associate_public_ip_address = true
-    security_groups = ["${aws_security_group.default.id}"]
+    security_groups = ["${aws_security_group.rabbit_required.id}", "${aws_security_group.provision-allow-ssh-REMOVE.id}"]
 
     tags {
         Name = "RabbitMQ ${var.env} ${count.index + 1}"

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -25,41 +25,49 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
     name      = "SR_ENVIRONMENT"
     value     = "${var.survey_runner_env}"
   }
+
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_RABBITMQ_URL"
     value     = "amqp://admin:admin@${aws_elb.rabbitmq.dns_name}:5672/%2F"
   }
+
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_RABBITMQ_QUEUE_NAME"
     value     = "${var.message_queue_name}"
   }
+
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_RABBITMQ_TEST_QUEUE_NAME"
     value     = "${var.message_queue_name}"
   }
+
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "InstanceType"
     value     = "${var.eb_instance_type}"
   }
+
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_LOG_LEVEL"
     value     = "${var.eq_sr_log_level}"
   }
+
    setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_SR_LOG_GROUP"
     value     = "${aws_cloudwatch_log_group.survey_runner.name}"
   }
+
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "AWS_ACCESS_KEY_ID"
     value     = "${var.aws_access_key}"
   }
+
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "AWS_SECRET_ACCESS_KEY"

--- a/vpc.tf
+++ b/vpc.tf
@@ -40,7 +40,8 @@ resource "aws_security_group" "default" {
   description = "Used for eQ"
   vpc_id      = "${aws_vpc.default.id}"
 
-  # SSH access from anywhere
+  # SSH access from anywhere.
+  # REMOVE in production via AWS console. 
   ingress {
     from_port   = 22
     to_port     = 22


### PR DESCRIPTION
**What**
This PR removes ssh access to the Elastic Beanstalk application surveys and
documents how to remove access to the RabbitMQ servers once provisioning has
succeeded.

**How to test**
1. Deploy this branch to dev AWS account.
2. Try to connect to Elastic Beanstalk servers as listed in console using telnet on port 22
3. Follow the instructions in the README.md to remove the security group rules and public addresses for the rabbitmq machines.

**Who can test**

Anyone but @dhilton 
