### PR TITLE
Restrict access to our elasticbeanstalk instance to a list of CIDR's

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -121,3 +121,7 @@ variable "aws_elastic_beanstalk_solution_stack_name" {
   description = "Elastic Beanstalk Amazon Linux version"
   default = "64bit Amazon Linux 2015.09 v2.0.8 running Python 3.4"
 }
+
+variable "ons_access_ips" {
+  description = "List of IP's or IP ranges to allow access to our service."
+}

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -27,6 +27,12 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
   }
 
   setting {
+    namespace = "aws:elb:loadbalancer"
+    name      = "ManagedSecurityGroup"
+    value     = "${aws_security_group.ons_ips.id}"
+  }
+
+  setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "SR_ENVIRONMENT"
     value     = "${var.survey_runner_env}"

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -21,6 +21,12 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
   }
 
   setting {
+    namespace = "aws:elb:loadbalancer"
+    name      = "SecurityGroups"
+    value     = "${aws_security_group.ons_ips.id}"
+  }
+
+  setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "SR_ENVIRONMENT"
     value     = "${var.survey_runner_env}"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -3,3 +3,4 @@ aws_secret_key="XXXXXXXXXXXX"
 sub_aws_access_key="XXXXXXXXXXXX"
 sub_aws_secret_key="XXXXXXXXXXXX"
 aws_key_pair="pre-prod"
+ons_access_ips=[XXXXXXX, XXXXXXX]

--- a/vpc.tf
+++ b/vpc.tf
@@ -41,7 +41,7 @@ resource "aws_security_group" "default" {
   vpc_id      = "${aws_vpc.default.id}"
 
   # SSH access from anywhere.
-  # REMOVE in production via AWS console. 
+  # REMOVE in production via AWS console.
   ingress {
     from_port   = 22
     to_port     = 22
@@ -135,5 +135,12 @@ resource "aws_security_group" "ons_ips" {
     to_port     = 80
     protocol    = "tcp"
     cidr_blocks = ["${split(",", var.ons_access_ips)}"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -118,3 +118,22 @@ resource "aws_security_group" "default" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
+
+# External access security group
+# Blocks access to an environment based on a
+# set of IP's in tfvars file.
+# Our default security group to access
+# the instances over SSH and HTTP
+resource "aws_security_group" "ons_ips" {
+  name        = "public_access_ip_restriction"
+  description = "Block access to only ONS IPs"
+  vpc_id      = "${aws_vpc.default.id}"
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["${split(",", var.ons_access_ips)}"]
+  }
+}


### PR DESCRIPTION
**What does this achieve?**

So that we can increase the security of our environments, this commit
creates a security group to restrict access to our ELB in front of our
EB ec2 instances. These IP's are set in the terraform TFVARS file.

**How to test**
1. Get the set of IP's off of @dhilton and set the correct values in your TFVARS file locally.
2. Run terraform apply for this branch
3. Check that you can reach the survey runner url
4. Check on a mobile network that you can't reach the survey runner url.

**Who can test**

Anyone but @dhilton
