### PR TITLE
Add tls configuration to elasticbeanstalk application

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -125,3 +125,7 @@ variable "aws_elastic_beanstalk_solution_stack_name" {
 variable "ons_access_ips" {
   description = "List of IP's or IP ranges to allow access to our service."
 }
+
+variable "certificate_arn" {
+  description = "ARN of the IAM loaded TLS certificate for public ELB"
+}

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -97,6 +97,30 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
     value     = "${var.cloudwatch_logging}"
   }
 
+  setting {
+    namespace = "aws:elb:listener:443"
+    name      = "ListenerProtocol"
+    value     = "HTTPS"
+  }
+
+  setting {
+    namespace = "aws:elb:listener:443"
+    name      = "SSLCertificateId"
+    value     = "${var.certificate_arn}"
+  }
+
+  setting {
+    namespace =  "aws:elb:listener:443"
+    name      = "InstancePort"
+    value = "80"
+  }
+
+  setting {
+    namespace  = "aws:elb:listener:443"
+    name       = "InstanceProtocol"
+    value      = "HTTP"
+  }
+
   # Extra settings still to implement
   # EQ_RRM_PUBLIC_KEY = os.getenv('EQ_RRM_PUBLIC_KEY', './jwt-test-keys/rrm-public.pem')
   # EQ_SR_PRIVATE_KEY = os.getenv('EQ_SR_PRIVATE_KEY', './jwt-test-keys/sr-private.pem')

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -4,3 +4,4 @@ sub_aws_access_key="XXXXXXXXXXXX"
 sub_aws_secret_key="XXXXXXXXXXXX"
 aws_key_pair="pre-prod"
 ons_access_ips=[XXXXXXX, XXXXXXX]
+certificate_arn="arn:aws:iam::XXXXXXX:server-certificate/NAME"

--- a/vpc.tf
+++ b/vpc.tf
@@ -122,8 +122,8 @@ resource "aws_security_group" "ons_ips" {
   vpc_id      = "${aws_vpc.default.id}"
 
   ingress {
-    from_port   = 80
-    to_port     = 80
+    from_port   = 443
+    to_port     = 443
     protocol    = "tcp"
     cidr_blocks = ["${split(",", var.ons_access_ips)}"]
   }

--- a/vpc.tf
+++ b/vpc.tf
@@ -40,15 +40,6 @@ resource "aws_security_group" "default" {
   description = "Used for eQ"
   vpc_id      = "${aws_vpc.default.id}"
 
-  # SSH access from anywhere.
-  # REMOVE in production via AWS console.
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   # HTTP access from the VPC
   ingress {
     from_port   = 80


### PR DESCRIPTION
**What**

To secure the access to our surveys, we intend to serve all pages over TLS. This PR adds support to our elasticbeanstalk(EB) application, to load a certificate from IAM into the EB environment. It references a new variable `certificate_arn` which is a reference to a certificate loaded into each environment / amazon account. 

**How to test**
1. Add a `certificate_arn` value to your tfvars file, point at for dev.
2. Run terraform apply with the env name of `test`
3. Visit the resulting url checking that you can't visit it on http and that https correctly works.
   (You may have a security warning due to it being a self-signed certificate in the dev env)

**Who can test**

Anyone but @dhilton 
