### PR TITLE
EQ-214 Performance changes

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -139,3 +139,7 @@ variable "ons_access_ips" {
 variable "certificate_arn" {
   description = "ARN of the IAM loaded TLS certificate for public ELB"
 }
+
+variable "application_secret_key" {
+  description = "The Flask secret key for secure cookie storage"
+}

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -87,6 +87,16 @@ variable "eb_instance_type" {
   default     = "t2.medium"
 }
 
+variable "eb_min_size" {
+  description = "Elastic Beanstalk Minimum number of instances"
+  default     = "2"
+}
+
+variable "eb_max_size" {
+  description = "Elastic Beanstalk Maximum number of instances"
+  default     = "2"
+}
+
 variable "rabbitmq_instance_type" {
   description = "Rabbit MQ Instance type"
   default = "t2.small"

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -57,6 +57,18 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
   }
 
   setting {
+    namespace = "aws:autoscaling:asg"
+    name      = "MaxSize"
+    value     = "${var.eb_max_size}"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:asg"
+    name      = "MinSize"
+    value     = "${var.eb_min_size}"
+  }
+
+  setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "InstanceType"
     value     = "${var.eb_instance_type}"
@@ -68,7 +80,7 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
     value     = "${var.eq_sr_log_level}"
   }
 
-   setting {
+  setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_SR_LOG_GROUP"
     value     = "${aws_cloudwatch_log_group.survey_runner.name}"

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -34,6 +34,12 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
 
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "EQ_SECRET_KEY"
+    value     = "${var.application_secret_key}"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
     name      = "SR_ENVIRONMENT"
     value     = "${var.survey_runner_env}"
   }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -5,3 +5,4 @@ sub_aws_secret_key="XXXXXXXXXXXX"
 aws_key_pair="pre-prod"
 ons_access_ips=[XXXXXXX, XXXXXXX]
 certificate_arn="arn:aws:iam::XXXXXXX:server-certificate/NAME"
+application_secret_key="you'll never guess it"


### PR DESCRIPTION
**What**
The minimum/maximum number of EC2 instances in the Elastic beanstalk application is now configurable. The default value is set to a min/max of 2/2 to prevent autoscaling.

Also setting the Flask application secret key as an environment, this is needed when more than one EC2 instance is running otherwise each instance has a different key and since we don't have sticky sessions the application will break if a user request hits a different server from the one that initial created the secure cookie.

**How to test**
1. Deploy this branch 
2. Check you have two elastic beanstalk EC2 instances
3. Complete a survey and ensure nothing is broken.

**Who can review**

Anyone apart from @warrenbailey
