### PR TITLE
Remove secondary network interfaces and staticly set ips of rabbitmq servers

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -110,7 +110,10 @@ variable "rabbitmq_ip_prime" {
 variable "rabbitmq_ip_failover" {
   description = "Static IP of secondary failover rabbitmq server"
 }
-
+variable "rabbitmq_ips" {
+  description = "Set of IPS for our rabbitmq machines static for VPN"
+  default = {}
+}
 variable "aws_elastic_beanstalk_solution_stack_name" {
   description = "Elastic Beanstalk Amazon Linux version"
   default = "64bit Amazon Linux 2016.03 v2.1.0 running Python 3.4"

--- a/message_queue.tf
+++ b/message_queue.tf
@@ -97,34 +97,12 @@ resource "aws_instance" "rabbitmq" {
     instance_type = "${var.rabbitmq_instance_type}"
     key_name = "${var.aws_key_pair}"
     subnet_id = "${aws_subnet.default.id}"
+    private_ip = "${lookup(var.rabbitmq_ips,count.index)}"
     associate_public_ip_address = true
     security_groups = ["${aws_security_group.rabbit_required.id}", "${aws_security_group.provision-allow-ssh-REMOVE.id}"]
 
     tags {
         Name = "RabbitMQ ${var.env} ${count.index + 1}"
-    }
-}
-
-# Static Network interfaces for the two RabbitMq boxes
-# Prime IP
-resource "aws_network_interface" "ons_vpn_prime" {
-    subnet_id = "${aws_subnet.default.id}"
-    private_ips = ["${var.rabbitmq_ip_prime}"]
-    security_groups = ["${aws_security_group.default.id}"]
-    attachment {
-        instance = "${aws_instance.rabbitmq.0.id}"
-        device_index = 1
-    }
-}
-
-# Failover IP
-resource "aws_network_interface" "ons_vpn_failover" {
-    subnet_id = "${aws_subnet.default.id}"
-    private_ips = ["${var.rabbitmq_ip_failover}"]
-    security_groups = ["${aws_security_group.default.id}"]
-    attachment {
-        instance = "${aws_instance.rabbitmq.1.id}"
-        device_index = 1
     }
 }
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -5,6 +5,9 @@ ons_access_ips=[XXXXXXX, XXXXXXX]
 certificate_arn="arn:aws:iam::XXXXXXX:server-certificate/NAME"
 application_secret_key="you'll never guess it"
 vpc_ip_block="10.30.20.0/24"
-rabbitmq_ip_prime="10.30.20.15"
-rabbitmq_ip_failover="10.30.20.16"
+rabbitmq_ip_prime="XX.XX.XX.15"
+rabbitmq_ip_failover="XX.XX.XX.16"
 google_analytics_code="UA-56892037-7"
+rabbitmq_ips.0="xx.xx.xx.15"
+rabbitmq_ips.1="xx.xx.xx.16"
+


### PR DESCRIPTION
**What**

To enable the VPN routing of connectivity to the rabbitmq servers to
work we need to allocate static ip's to our two rabbitmq servers.

Previously we did this by creating two new interfaces and attaching them to the servers.
This commit simplifies the design by just allocating those IP's to the instances
as they come up.

**How to test**
1. Checkout this branch and deploy an environment
2. In the AWS console check that the rabbitmq machines have one network interface each
3. Check that the IP's end in X.15 or X.16

**Who can test?**

Anyone but @dhilton 
