### PR TITLE
[eq-219] Create security groups to manage VPN provided services

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -134,3 +134,15 @@ variable "application_secret_key" {
 variable "google_analytics_code" {
   description = "The google analytics UA Code"
 }
+
+variable "logserver_cidr" {
+  description="CIDR block of the centralised logging service"
+}
+
+variable "audit_cidr" {
+  description="CIDR block of the centralised auditing service."
+}
+
+variable "sdx_cidr" {
+  description="CIDR block of the sdx system."
+}

--- a/message_queue.tf
+++ b/message_queue.tf
@@ -10,6 +10,13 @@ resource "aws_security_group" "provision-allow-ssh-REMOVE" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
     }
+    # outbound internet access
+    egress {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
 }
 
 
@@ -79,14 +86,6 @@ resource "aws_security_group" "rabbit_required" {
     cidr_blocks = ["${var.vpc_ip_block}"]
   }
   # End RabbitMQ ports
-
-  # outbound internet access
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 }
 
 
@@ -99,7 +98,10 @@ resource "aws_instance" "rabbitmq" {
     subnet_id = "${aws_subnet.default.id}"
     private_ip = "${lookup(var.rabbitmq_ips,count.index)}"
     associate_public_ip_address = true
-    security_groups = ["${aws_security_group.rabbit_required.id}", "${aws_security_group.provision-allow-ssh-REMOVE.id}"]
+    security_groups = ["${aws_security_group.rabbit_required.id}",
+                        "${aws_security_group.provision-allow-ssh-REMOVE.id}",
+                        "${aws_security_group.vpn_services_logging_auditing.id}",
+                        "${aws_security_group.vpn_sdx_access.id}"]
 
     tags {
         Name = "RabbitMQ ${var.env} ${count.index + 1}"

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -27,6 +27,12 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
   }
 
   setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SecurityGroups"
+    value     = "${aws_security_group.vpn_services_logging_auditing.id}"
+  }
+
+  setting {
     namespace = "aws:elb:loadbalancer"
     name      = "ManagedSecurityGroup"
     value     = "${aws_security_group.ons_ips.id}"
@@ -144,10 +150,6 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
     name       = "InstanceProtocol"
     value      = "HTTP"
   }
-
-  # Extra settings still to implement
-  # EQ_RRM_PUBLIC_KEY = os.getenv('EQ_RRM_PUBLIC_KEY', './jwt-test-keys/rrm-public.pem')
-  # EQ_SR_PRIVATE_KEY = os.getenv('EQ_SR_PRIVATE_KEY', './jwt-test-keys/sr-private.pem')
 
   provisioner "local-exec" {
        command = "./deploy_surveyrunner.sh ${var.env}-surveyrunner ${var.env}-prime"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -10,4 +10,6 @@ rabbitmq_ip_failover="XX.XX.XX.16"
 google_analytics_code="UA-56892037-7"
 rabbitmq_ips.0="xx.xx.xx.15"
 rabbitmq_ips.1="xx.xx.xx.16"
-
+logserver_cidr="x.x.x.21/32"
+audit_cidr="x.x.x.242/32"
+sdx_cidr="x.x.x.0/32"

--- a/vpc.tf
+++ b/vpc.tf
@@ -36,7 +36,7 @@ resource "aws_subnet" "default" {
 # Our default security group to access
 # the instances over SSH and HTTP
 resource "aws_security_group" "default" {
-  name        = "survey_runner"
+  name        = "${var.en}-survey_runner"
   description = "Used for eQ"
   vpc_id      = "${aws_vpc.default.id}"
 
@@ -117,7 +117,7 @@ resource "aws_security_group" "default" {
 # Our default security group to access
 # the instances over SSH and HTTP
 resource "aws_security_group" "ons_ips" {
-  name        = "public_access_ip_restriction"
+  name        = "${var.en}-public_access_ip_restriction"
   description = "Block access to only ONS IPs"
   vpc_id      = "${aws_vpc.default.id}"
 
@@ -138,7 +138,7 @@ resource "aws_security_group" "ons_ips" {
 
 # VPN services control group
 resource "aws_security_group" "vpn_services_logging_auditing" {
-  name        = "vpn_services_logging_auditing"
+  name        = "${var.en}-vpn_services_logging_auditing"
   description = "Allow the VPN provided services to access our VPC"
   vpc_id      = "${aws_vpc.default.id}"
 
@@ -171,7 +171,7 @@ resource "aws_security_group" "vpn_services_logging_auditing" {
 }
 
 resource "aws_security_group" "vpn_sdx_access" {
-  name        = "vpn_services_sdx_access"
+  name        = "${var.en}-vpn_services_sdx_access"
   description = "Allow the sdx system access to RabbitMQ servers."
   vpc_id      = "${aws_vpc.default.id}"
 

--- a/vpc.tf
+++ b/vpc.tf
@@ -135,3 +135,62 @@ resource "aws_security_group" "ons_ips" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
+# VPN services control group
+resource "aws_security_group" "vpn_services_logging_auditing" {
+  name        = "vpn_services_logging_auditing"
+  description = "Allow the VPN provided services to access our VPC"
+  vpc_id      = "${aws_vpc.default.id}"
+
+  # Auditing service
+  egress {
+    from_port   = 601
+    to_port     = 601
+    protocol    = "tcp"
+    cidr_blocks = ["${var.audit_cidr}"]
+  }
+  egress {
+    from_port   = 514
+    to_port     = 514
+    protocol    = "udp"
+    cidr_blocks = ["${var.audit_cidr}"]
+  }
+  # Log service
+  egress {
+    from_port   = 514
+    to_port     = 514
+    protocol    = "udp"
+    cidr_blocks = ["${var.logserver_cidr}"]
+  }
+  egress {
+    from_port   = 9997
+    to_port     = 9997
+    protocol    = "tcp"
+    cidr_blocks = ["${var.logserver_cidr}"]
+  }
+}
+
+resource "aws_security_group" "vpn_sdx_access" {
+  name        = "vpn_services_sdx_access"
+  description = "Allow the sdx system access to RabbitMQ servers."
+  vpc_id      = "${aws_vpc.default.id}"
+
+  # RabbitMQ access from SDX to queue servers
+  ingress {
+    from_port   = 5672
+    to_port     = 5672
+    protocol    = "tcp"
+    cidr_blocks = ["${var.sdx_cidr}"]
+  }
+}
+
+# egress
+# Security all boxes to 10.172.92.242/32 udp 514 / tcp 601 - selex
+# Security group all boxes 10.171.93.21/32 udp 514 / tcp 9997 - Splunk
+#
+
+# ingress
+# To rabbitmq servers from SDX on port 5672
+# To Jenkins server from 10.27.0.0/16 ports 22 / 8080
+# To Jenkins server from 10.47.0.0/16 ports 22 / 8080
+# To Jenkins server from 10.171.93.21 ports 22 / 8080

--- a/vpc.tf
+++ b/vpc.tf
@@ -36,7 +36,7 @@ resource "aws_subnet" "default" {
 # Our default security group to access
 # the instances over SSH and HTTP
 resource "aws_security_group" "default" {
-  name        = "${var.en}-survey_runner"
+  name        = "${var.env}-survey_runner"
   description = "Used for eQ"
   vpc_id      = "${aws_vpc.default.id}"
 
@@ -117,7 +117,7 @@ resource "aws_security_group" "default" {
 # Our default security group to access
 # the instances over SSH and HTTP
 resource "aws_security_group" "ons_ips" {
-  name        = "${var.en}-public_access_ip_restriction"
+  name        = "${var.env}-public_access_ip_restriction"
   description = "Block access to only ONS IPs"
   vpc_id      = "${aws_vpc.default.id}"
 
@@ -138,7 +138,7 @@ resource "aws_security_group" "ons_ips" {
 
 # VPN services control group
 resource "aws_security_group" "vpn_services_logging_auditing" {
-  name        = "${var.en}-vpn_services_logging_auditing"
+  name        = "${var.env}-vpn_services_logging_auditing"
   description = "Allow the VPN provided services to access our VPC"
   vpc_id      = "${aws_vpc.default.id}"
 
@@ -171,7 +171,7 @@ resource "aws_security_group" "vpn_services_logging_auditing" {
 }
 
 resource "aws_security_group" "vpn_sdx_access" {
-  name        = "${var.en}-vpn_services_sdx_access"
+  name        = "${var.env}-vpn_services_sdx_access"
   description = "Allow the sdx system access to RabbitMQ servers."
   vpc_id      = "${aws_vpc.default.id}"
 


### PR DESCRIPTION
**What**
This commit creates a set of security groups to enable the
vpn services that traverse from the inner estate to the aws VPC.

**How to test**
1. Add the new variables from `terraform.tfvars.example` to you local settings file with the correct values for your environment.
2. Deploy this branch.
3. Check that the security groups have been created with the access correctly setup to push data to the auditing and logging servers, whilst allowing the sdx machine(s) to access the rabbitmq servers.

**Who can test**

Anyone but @dhilton
