### PR TITLE
The health check should send messages to the test queue

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -30,6 +30,11 @@ variable "message_queue_name" {
   default     = "submit_q"
 }
 
+variable "message_test_queue_name" {
+  description = "RabbitMQ health check queue name"
+  default     = "test_q"
+}
+
 variable "survey_runner_env" {
   description = "The name of the survey runner environment, which is set as a environment variable."
   default     = "development"

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -65,7 +65,7 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_RABBITMQ_TEST_QUEUE_NAME"
-    value     = "${var.message_queue_name}"
+    value     = "${var.message_test_queue_name}"
   }
 
   setting {


### PR DESCRIPTION
_**What_*
The health check should send messages to the test queue rather than the submission queue.

**How to test**
1. Deploy this branch using terraform
2. Check the elastic beanstalk configuration for your environment - EQ_RABBITMQ_TEST_QUEUE_NAME should be set to test_q
3. Browse to the health check and then check there is a message on the rabbit mq queue 'test_q'

**Who can review**
Anyone apart from @warrenbailey
