### PR TITLE
Set default log level to ERROR

### DIFF
--- a/global_vars.tf
+++ b/global_vars.tf
@@ -71,7 +71,7 @@ variable "rabbitmq_write_password" {
 
 variable "eq_sr_log_level" {
   description = "The Survey Runner logging level (One of ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'])"
-  default     = "WARNING"
+  default     = "ERROR"
 }
 
 variable "eb_instance_type" {


### PR DESCRIPTION
**What**
Changing the default log level from WARNING to ERROR. 

**How to test**
1. Run terraform apply and check the elastic beanstalk log level is ERROR
2. Check that only error messages appear in cloudwatch logs

**Who can review**
Anyone apart from @warrenbailey
