### PR TITLE
Adding IAM instance profile for elastic beanstalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ For the smoke test you will need
 2. Gem 2.5.2 (gem update --system '2.5.2')
 3. Bundle should be 1.10.6 (gem install bundler -v 1.10.6)
 
+## IAM Role
+Currently for this to work you need to add the CloudWatchFullAccess policy to the IAM role aws-elasticbeanstalk-ec2-role
+using the IAM console in AWS
+
 ## Additional security
 
 To increase the security of the system, remove the security group `"provision-allow-ssh-REMOVE`

--- a/database.tf
+++ b/database.tf
@@ -12,7 +12,7 @@ resource "aws_security_group" "rds_access" {
 }
 
 resource "aws_db_subnet_group" "rds" {
-    name = "eq-rds"
+    name = "${var.env}-eq-rds"
     description = "The two database subnets"
     subnet_ids = ["${aws_subnet.database-1.id}", "${aws_subnet.database-2.id}"]
     tags {
@@ -22,7 +22,7 @@ resource "aws_db_subnet_group" "rds" {
 
 resource "aws_db_instance" "database" {
   allocated_storage    = 10
-  identifier           = "digitaleqrds"
+  identifier           = "${var.env}-digitaleqrds"
   engine               = "postgres"
   engine_version       = "9.4.5"
   instance_class       = "db.m1.small"

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -197,3 +197,15 @@ variable "database_password" {
 variable "elastic_beanstalk_iam_role" {
   default = "aws-elasticbeanstalk-ec2-role"
 }
+
+variable "eq_server_side_storage" {
+  default = "False"
+}
+
+variable "eq_server_side_storage_encryption" {
+  default = "True"
+}
+
+variable "eq_server_side_storage_type" {
+  default = "DATABASE"
+}

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -193,3 +193,7 @@ variable "database_password" {
   description = "The password for the master username of the database"
   default = "digitaleq12345"
 }
+
+variable "elastic_beanstalk_iam_role" {
+  default = "aws-elasticbeanstalk-ec2-role"
+}

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -3,12 +3,6 @@ resource "aws_elastic_beanstalk_application" "surveyrunner" {
   description = "Survey runner for environment"
 }
 
-resource "aws_iam_instance_profile" "eb_profile" {
-    name = "${var.env}-eb-iam-instance-profile"
-    roles = ["aws-elasticbeanstalk-ec2-role"]
-}
-
-
 resource "aws_elastic_beanstalk_environment" "sr_prime" {
   name = "${var.env}-prime"
   application = "${aws_elastic_beanstalk_application.surveyrunner.name}"
@@ -47,7 +41,7 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
    setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "IamInstanceProfile"
-    value     = "${aws_iam_instance_profile.eb_profile.name}"
+    value     = "${var.elastic_beanstalk_iam_role}"
   }
 
   setting {
@@ -116,17 +110,6 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
     value     = "${aws_cloudwatch_log_group.survey_runner.name}"
   }
 
-  setting {
-    namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "AWS_ACCESS_KEY_ID"
-    value     = "${var.aws_access_key}"
-  }
-
-  setting {
-    namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "AWS_SECRET_ACCESS_KEY"
-    value     = "${var.aws_secret_key}"
-  }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "AWS_DEFAULT_REGION"

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -161,19 +161,19 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_SERVER_SIDE_STORAGE"
-    value     = "True"
+    value     = "${var.eq_server_side_storage}"
   }
 
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_SERVER_SIDE_STORAGE_ENCRYPTION"
-    value     = "True"
+    value     = "${var.eq_server_side_storage_encryption}"
   }
 
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_SERVER_SIDE_STORAGE_TYPE"
-    value     = "DATABASE"
+    value     = "${var.eq_server_side_storage_type}"
   }
 
   setting {

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -5,25 +5,7 @@ resource "aws_elastic_beanstalk_application" "surveyrunner" {
 
 resource "aws_iam_instance_profile" "eb_profile" {
     name = "${var.env}-eb-iam-instance-profile"
-    roles = ["${aws_iam_role.role.name}"]
-}
-
-resource "aws_iam_role" "role" {
-    name = "${var.env}-eb-iam-role"
-    path = "/"
-    assume_role_policy = <<EOF
-{
- "Version": "2012-10-17",
- "Statement": [
-    {
-        "Action": "sts:AssumeRole",
-        "Principal": {"AWS": "*"},
-        "Effect": "Allow",
-        "Sid": ""
-    }
-]
-}
-EOF
+    roles = ["aws-elasticbeanstalk-ec2-role"]
 }
 
 

--- a/survey_runner.tf
+++ b/survey_runner.tf
@@ -3,6 +3,30 @@ resource "aws_elastic_beanstalk_application" "surveyrunner" {
   description = "Survey runner for environment"
 }
 
+resource "aws_iam_instance_profile" "eb_profile" {
+    name = "${var.env}-eb-iam-instance-profile"
+    roles = ["${aws_iam_role.role.name}"]
+}
+
+resource "aws_iam_role" "role" {
+    name = "${var.env}-eb-iam-role"
+    path = "/"
+    assume_role_policy = <<EOF
+{
+ "Version": "2012-10-17",
+ "Statement": [
+    {
+        "Action": "sts:AssumeRole",
+        "Principal": {"AWS": "*"},
+        "Effect": "Allow",
+        "Sid": ""
+    }
+]
+}
+EOF
+}
+
+
 resource "aws_elastic_beanstalk_environment" "sr_prime" {
   name = "${var.env}-prime"
   application = "${aws_elastic_beanstalk_application.surveyrunner.name}"
@@ -36,6 +60,12 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
     namespace = "aws:ec2:vpc"
     name = "AssociatePublicIpAddress"
     value = "true"
+  }
+
+   setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = "${aws_iam_instance_profile.eb_profile.name}"
   }
 
   setting {


### PR DESCRIPTION
**What**
Adds an IAM instance profile for elastic beanstalk to speed up deployments.

**How to test**
1. Deploy terraform and check everything still works
2. Log into AWS, go to elastic beanstalks settings and change something. Notice the warning no longer exists.

**Who can review**
Anyone apart from @warrenbailey
