### PR TITLE
Adding cloud watch alarms for the Database

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -53,3 +53,48 @@ resource "aws_cloudwatch_metric_alarm" "rabbitmq2_status" {
     alarm_actions = ["${var.cloudwatch_alarm_arn}"]
     dimensions { "InstanceId"="${aws_instance.rabbitmq.1.id}"}
 }
+
+resource "aws_cloudwatch_metric_alarm" "database_storage_alert" {
+    alarm_name = "${var.env}-database-storage-alert"
+    evaluation_periods = "1"
+    comparison_operator = "LessThanOrEqualToThreshold"
+    metric_name = "FreeStorageSpace"
+    namespace ="AWS/RDS"
+    period ="300"
+    statistic ="Average"
+    threshold ="1073741824"
+    evaluation_periods="1"
+    alarm_description = "Alert generated if the DB has less than a 1gb of spage left"
+    alarm_actions = ["arn:aws:sns:eu-west-1:853958762481:slack-alarm"]
+    dimensions { "DBInstanceIdentifier"="${aws_db_instance.database.identifier}"}
+}
+
+resource "aws_cloudwatch_metric_alarm" "database_cpu_alert" {
+    alarm_name = "${var.env}-database-cpu-alert"
+    evaluation_periods = "1"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    metric_name = "CPUUtilization"
+    namespace ="AWS/RDS"
+    period ="300"
+    statistic ="Average"
+    threshold ="80"
+    evaluation_periods="1"
+    alarm_description = "Alert generated if the DB is using more than 80% CPU"
+    alarm_actions = ["${var.cloudwatch_alarm_arn}"]
+    dimensions { "DBInstanceIdentifier"="${aws_db_instance.database.identifier}"}
+}
+
+resource "aws_cloudwatch_metric_alarm" "database_free_memory_alert" {
+    alarm_name = "${var.env}-database-free-memory-alert"
+    evaluation_periods = "1"
+    comparison_operator = "LessThanOrEqualToThreshold"
+    metric_name = "FreeableMemory"
+    namespace ="AWS/RDS"
+    period ="300"
+    statistic ="Average"
+    threshold ="524288000"
+    evaluation_periods="1"
+    alarm_description = "Alert generated if the DB has less than a 512MB of memory left"
+    alarm_actions = ["arn:aws:sns:eu-west-1:853958762481:slack-alarm"]
+    dimensions { "DBInstanceIdentifier"="${aws_db_instance.database.identifier}"}
+}


### PR DESCRIPTION
**What**
Adding three new cloud watch alarms:
1. Database CPU is greater than 80%
2. Database Free memory is less than 512MB
3. Database storage is less than 1GB

**How to test**
1. Create a new environment using terraform
2. Check the alarms above have been created

**Who can review**
Anyone apart from @warrenbailey
