### PR TITLE
EQ-378: Moving to Server Side Storage

### DIFF
--- a/survey-runner/global_vars.tf
+++ b/survey-runner/global_vars.tf
@@ -198,10 +198,6 @@ variable "elastic_beanstalk_iam_role" {
   default = "aws-elasticbeanstalk-ec2-role-runner"
 }
 
-variable "eq_server_side_storage" {
-  default = "False"
-}
-
 variable "eq_server_side_storage_encryption" {
   default = "True"
 }

--- a/survey-runner/survey_runner.tf
+++ b/survey-runner/survey_runner.tf
@@ -166,12 +166,6 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
 
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "EQ_SERVER_SIDE_STORAGE"
-    value     = "${var.eq_server_side_storage}"
-  }
-
-  setting {
-    namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_SERVER_SIDE_STORAGE_ENCRYPTION"
     value     = "${var.eq_server_side_storage_encryption}"
   }


### PR DESCRIPTION
**_What**_
Removes the Server side storage flag as this is no longer needed (client side is due to be removed in https://github.com/ONSdigital/eq-survey-runner/pull/249)

**_How to test**_
1. Check out this branch
2. Deploy an environment using terraform
3. Check you can complete a survey successfully

**_Who can review**_
Anyone apart from @warrenbailey
