### PR TITLE
EQ-376: Change the IAM role to limit access

### DIFF
--- a/author/global_vars.tf
+++ b/author/global_vars.tf
@@ -76,7 +76,7 @@ variable "aws_elastic_beanstalk_solution_stack_name" {
 }
 
 variable "elastic_beanstalk_iam_role" {
-  default = "aws-elasticbeanstalk-ec2-role"
+  default = "aws-elasticbeanstalk-ec2-role-author"
 }
 
 variable "eb_instance_type" {


### PR DESCRIPTION
**What**

This change restricts the IAM profile used to just reading and writing to S3 service, so that we can be safe in the knowledge that the author Elastic Beanstalk application can not use any other AWS services.

**How to test**
1. Create a new IAM role called `aws-elasticbeanstalk-ec2-role-author` with the policy of only having read/write access to S3.
2. Deploy to an environment
3. Check that you can save and reload schemas from the S3 bucket.

**Who can test**

Anyone but @dhilton
