### PR TITLE
Restrict the IAM role to just read from s3

### DIFF
--- a/survey-runner/global_vars.tf
+++ b/survey-runner/global_vars.tf
@@ -195,7 +195,7 @@ variable "database_password" {
 }
 
 variable "elastic_beanstalk_iam_role" {
-  default = "aws-elasticbeanstalk-ec2-role"
+  default = "aws-elasticbeanstalk-ec2-role-runner"
 }
 
 variable "eq_server_side_storage" {


### PR DESCRIPTION
**What**

This PR restricts the runner to using a IAM profile that only allows the runner to read from S3.

**How to test**
1. Create a IAM role called `"aws-elasticbeanstalk-ec2-role-runner` and give it only read access to S3.
2. Deploy this branch to an environment.
3. Check that you can read from S3 and launch a survey.

**Who can test**

Anyone but @dhilton 
