### PR TITLE
Eq 386 Cloudwatch Monitoring for Rabbit MQ Clusters

### DIFF
--- a/survey-runner/cloudwatch.tf
+++ b/survey-runner/cloudwatch.tf
@@ -1,3 +1,29 @@
+resource "aws_cloudwatch_metric_alarm" "rabbitmq1_cluster_status" {
+    alarm_name = "${var.env}-rabbitmq1-cluster-alert"
+    evaluation_periods = "1"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    metric_name = "${var.env}-rabbitmq1"
+    namespace ="RabbitMQClusterStatus"
+    period ="300"
+    statistic ="Average"
+    threshold ="1"
+    alarm_description = "${var.env} rabbit mq 1 reporting cluster paritions"
+    alarm_actions = ["${var.cloudwatch_alarm_arn}"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "rabbitmq2_cluster_status" {
+    alarm_name = "${var.env}-rabbitmq2-cluster-alert"
+    evaluation_periods = "1"
+    comparison_operator = "GreaterThanOrEqualToThreshold"
+    metric_name = "${var.env}-rabbitmq2"
+    namespace ="RabbitMQClusterStatus"
+    period ="300"
+    statistic ="Average"
+    threshold ="1"
+    alarm_description = "${var.env} rabbit mq 2 reporting cluster paritions"
+    alarm_actions = ["${var.cloudwatch_alarm_arn}"]
+}
+
 resource "aws_cloudwatch_metric_alarm" "rabbitmq1_cpu" {
     alarm_name = "${var.env}-rabbitmq1-cpu-alert"
     evaluation_periods = "1"

--- a/survey-runner/iam.tf
+++ b/survey-runner/iam.tf
@@ -1,0 +1,48 @@
+resource "aws_iam_role_policy" "rabbitmq-policy" {
+    name = "rabbit-mq-${var.env}-policy"
+    role = "${aws_iam_role.rabbitmq-role.name}"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "autoscaling:Describe*",
+        "cloudwatch:*",
+        "logs:*",
+        "sns:*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+
+resource "aws_iam_instance_profile" "rabbitmq-instance-profile" {
+    name = "rabbit-mq-${var.env}-instance-profile"
+    roles = ["${aws_iam_role.rabbitmq-role.name}"]
+}
+
+resource "aws_iam_role" "rabbitmq-role" {
+    name = "rabbit-mq-${var.env}-role"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+

--- a/survey-runner/message_queue.tf
+++ b/survey-runner/message_queue.tf
@@ -91,7 +91,7 @@ resource "aws_security_group" "rabbit_required" {
 
 resource "aws_instance" "rabbitmq" {
     ami = "ami-47a23a30"
-    iam_instance_profile="rabbitmq-role"
+    iam_instance_profile="${aws_iam_instance_profile.rabbitmq-instance-profile.name}"
     count = 2
     instance_type = "${var.rabbitmq_instance_type}"
     key_name = "${var.aws_key_pair}"
@@ -236,7 +236,7 @@ resource "null_resource" "ansible" {
     }
 
     provisioner "local-exec" {
-      command = "ansible-playbook -vvvv -i '${var.env}-rabbitmq1.${var.dns_zone_name},${var.env}-rabbitmq2.${var.dns_zone_name}'  --private-key ${var.aws_key_pair}.pem tmp/eq-messaging/ansible/rabbitmq-cluster.yml --extra-vars '{\"deploy_env\":\"${var.env}\",\"deploy_dns\":\"${var.dns_zone_name}\",\"rabbitmq_admin_user\":\"${var.rabbitmq_admin_user}\",\"rabbitmq_admin_password\":\"${var.rabbitmq_admin_password}\",\"rabbitmq_write_user\":\"${var.rabbitmq_write_user}\",\"rabbitmq_write_password\":\"${var.rabbitmq_write_password}\",\"rabbitmq_read_user\":\"${var.rabbitmq_read_user}\",\"rabbitmq_read_password\":\"${var.rabbitmq_read_password}\", \"rsyslogd_server_IP\":\"${var.rsyslogd_server_ip}\", \"region\":\"${var.aws_default_region}\"}'"
+      command = "ansible-playbook -i '${var.env}-rabbitmq1.${var.dns_zone_name},${var.env}-rabbitmq2.${var.dns_zone_name}'  --private-key ${var.aws_key_pair}.pem tmp/eq-messaging/ansible/rabbitmq-cluster.yml --extra-vars '{\"deploy_env\":\"${var.env}\",\"deploy_dns\":\"${var.dns_zone_name}\",\"rabbitmq_admin_user\":\"${var.rabbitmq_admin_user}\",\"rabbitmq_admin_password\":\"${var.rabbitmq_admin_password}\",\"rabbitmq_write_user\":\"${var.rabbitmq_write_user}\",\"rabbitmq_write_password\":\"${var.rabbitmq_write_password}\",\"rabbitmq_read_user\":\"${var.rabbitmq_read_user}\",\"rabbitmq_read_password\":\"${var.rabbitmq_read_password}\", \"rsyslogd_server_IP\":\"${var.rsyslogd_server_ip}\", \"region\":\"${var.aws_default_region}\"}'"
     }
     provisioner "local-exec" {
       command = "rm -rf tmp"

--- a/survey-runner/message_queue.tf
+++ b/survey-runner/message_queue.tf
@@ -89,9 +89,9 @@ resource "aws_security_group" "rabbit_required" {
 }
 
 
-
 resource "aws_instance" "rabbitmq" {
     ami = "ami-47a23a30"
+    iam_instance_profile="rabbitmq-role"
     count = 2
     instance_type = "${var.rabbitmq_instance_type}"
     key_name = "${var.aws_key_pair}"
@@ -236,7 +236,7 @@ resource "null_resource" "ansible" {
     }
 
     provisioner "local-exec" {
-      command = "ansible-playbook -i '${var.env}-rabbitmq1.${var.dns_zone_name},${var.env}-rabbitmq2.${var.dns_zone_name}'  --private-key ${var.aws_key_pair}.pem tmp/eq-messaging/ansible/rabbitmq-cluster.yml --extra-vars '{\"deploy_env\":\"${var.env}\",\"deploy_dns\":\"${var.dns_zone_name}\",\"rabbitmq_admin_user\":\"${var.rabbitmq_admin_user}\",\"rabbitmq_admin_password\":\"${var.rabbitmq_admin_password}\",\"rabbitmq_write_user\":\"${var.rabbitmq_write_user}\",\"rabbitmq_write_password\":\"${var.rabbitmq_write_password}\",\"rabbitmq_read_user\":\"${var.rabbitmq_read_user}\",\"rabbitmq_read_password\":\"${var.rabbitmq_read_password}\", \"rsyslogd_server_IP\":\"${var.rsyslogd_server_ip}\"}'"
+      command = "ansible-playbook -vvvv -i '${var.env}-rabbitmq1.${var.dns_zone_name},${var.env}-rabbitmq2.${var.dns_zone_name}'  --private-key ${var.aws_key_pair}.pem tmp/eq-messaging/ansible/rabbitmq-cluster.yml --extra-vars '{\"deploy_env\":\"${var.env}\",\"deploy_dns\":\"${var.dns_zone_name}\",\"rabbitmq_admin_user\":\"${var.rabbitmq_admin_user}\",\"rabbitmq_admin_password\":\"${var.rabbitmq_admin_password}\",\"rabbitmq_write_user\":\"${var.rabbitmq_write_user}\",\"rabbitmq_write_password\":\"${var.rabbitmq_write_password}\",\"rabbitmq_read_user\":\"${var.rabbitmq_read_user}\",\"rabbitmq_read_password\":\"${var.rabbitmq_read_password}\", \"rsyslogd_server_IP\":\"${var.rsyslogd_server_ip}\", \"region\":\"${var.aws_default_region}\"}'"
     }
     provisioner "local-exec" {
       command = "rm -rf tmp"


### PR DESCRIPTION
**_What**_
See https://github.com/ONSdigital/eq-messaging/pull/8

This PR adds the cloudwatch alerts and the IAM roles necessary for the metrics to trigger an alarm

**How to test**
1. Checkout this branch
2. Change the message_queue.tf to point at the eq-messaging branch

```
  provisioner "local-exec" {
      command = "git clone -b eq-386-rabbit-cluster-statusx https://github.com/ONSdigital/eq-messaging.git tmp/eq-messaging"
    }
```
1. Run terraform apply
2. Check the new Rabbit MQ metrics exist
3. Check the new Rabbit MQ alarms exist

**Who can review**
Anyone apart from @warrenbailey
