### PR TITLE
Remove ELB in front of RabbitMQ servers 

### DIFF
--- a/survey-runner/message_queue.tf
+++ b/survey-runner/message_queue.tf
@@ -88,7 +88,6 @@ resource "aws_security_group" "rabbit_required" {
   # End RabbitMQ ports
 }
 
-
 resource "aws_instance" "rabbitmq" {
     ami = "ami-47a23a30"
     iam_instance_profile="${aws_iam_instance_profile.rabbitmq-instance-profile.name}"
@@ -107,47 +106,6 @@ resource "aws_instance" "rabbitmq" {
         Name = "RabbitMQ ${var.env} ${count.index + 1}"
     }
 }
-
-
-resource "aws_elb" "rabbitmq" {
-  name = "${var.env}-rabbitmq-elb"
-  subnets = ["${aws_subnet.sr_application.id}"]
-  security_groups = ["${aws_security_group.survey_runner_default.id}"]
-  internal = true
-
-  listener {
-    instance_port = 5672
-    instance_protocol = "TCP"
-    lb_port = 5672
-    lb_protocol = "TCP"
-  }
-  listener {
-    instance_port = 5673
-    instance_protocol = "TCP"
-    lb_port = 5673
-    lb_protocol = "TCP"
-  }
-
-  instances = ["${aws_instance.rabbitmq.0.id}", "${aws_instance.rabbitmq.1.id}"]
-  cross_zone_load_balancing = true
-  idle_timeout = 400
-  connection_draining = true
-  connection_draining_timeout = 400
-
-  tags {
-    Name = "${var.env}-rabbitmq-elb"
-  }
-}
-
-
-resource "aws_route53_record" "rabbitmq" {
-  zone_id = "${var.dns_zone_id}"
-  name = "${var.env}-rabbitmq.${var.dns_zone_name}"
-  type = "CNAME"
-  ttl = "60"
-  records = ["${aws_elb.rabbitmq.dns_name}"]
-}
-
 
 resource "template_file" "hosts" {
     template = "${file("templates/hosts")}"

--- a/survey-runner/outputs.tf
+++ b/survey-runner/outputs.tf
@@ -1,9 +1,6 @@
 output "key_pair_name" {
 	value = "${var.aws_key_pair}"
 }
-output "rabbitmq_elb_address" {
-	value = "${aws_elb.rabbitmq.dns_name}"
-}
 output "survey_runner_elb_address" {
   value = "${aws_route53_record.survey_runner.fqdn}"
 }

--- a/survey-runner/survey_runner.tf
+++ b/survey-runner/survey_runner.tf
@@ -65,7 +65,13 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_RABBITMQ_URL"
-    value     = "amqp://${var.rabbitmq_write_user}:${var.rabbitmq_write_password}@${aws_elb.rabbitmq.dns_name}:5672/%2F"
+    value     = "amqp://${var.rabbitmq_write_user}:${var.rabbitmq_write_password}@${aws_instance.rabbitmq.0.private_ip}:5672/%2F"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "EQ_RABBITMQ_URL_FAILOVER"
+    value     = "amqp://${var.rabbitmq_write_user}:${var.rabbitmq_write_password}@${aws_instance.rabbitmq.1.private_ip}:5672/%2F"
   }
 
   setting {

--- a/survey-runner/survey_runner.tf
+++ b/survey-runner/survey_runner.tf
@@ -70,7 +70,7 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
 
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "EQ_RABBITMQ_URL_FAILOVER"
+    name      = "EQ_RABBITMQ_URL_SECONDARY"
     value     = "amqp://${var.rabbitmq_write_user}:${var.rabbitmq_write_password}@${aws_instance.rabbitmq.1.private_ip}:5672/%2F"
   }
 

--- a/survey-runner/vpc.tf
+++ b/survey-runner/vpc.tf
@@ -23,8 +23,6 @@ resource "aws_route" "survey_runner_internet_access" {
 }
 
 
-
-
 # Our default security group to access
 # the instances over SSH and HTTP
 resource "aws_security_group" "survey_runner_default" {
@@ -182,7 +180,7 @@ resource "aws_security_group" "survey_runner_vpn_sdx_access" {
   }
 }
 
-# Subnets for ElasticBeanstalk / Jenkins / WAF
+# Subnets for ElasticBeanstalk / Jenkins 
 # Create a subnet to launch our ec2 instances and ElasticBeanstalk into
 resource "aws_subnet" "sr_application" {
   vpc_id                  = "${aws_vpc.survey_runner_default.id}"


### PR DESCRIPTION
**What**
This PR removes the ELB in front of the Rabbitmq servers as during network partitioning we saw
messages get stuck on a partitioned cluster. This requires a change in our connection logic from
the survey runner to before being deployed to live, as we no longer will automatically failover in
the event of the prime (main) Rabbitmq server failing.

**How to test**
1. Checkout this branch and deploy an environment, with the appropriate equivalent branch from eq-survey-runner
2. Ensure that the application passes messages through the queue.

**Who can test**

Anyone but @dhilton 
