### PR TITLE
Adding an key pair to elastic beanstalk to allow SSH access to the database

### DIFF
--- a/survey-runner/global_vars.tf
+++ b/survey-runner/global_vars.tf
@@ -15,6 +15,11 @@ variable "aws_key_pair" {
     default="pre-prod"
 }
 
+variable "elastic_beanstalk_aws_key_pair" {
+    description = "Amazon Web Service Key Pair for use by elastic beanstalk - in production this value should be empty"
+    default=""
+}
+
 variable "dns_zone_id" {
   description = "Amazon Route53 DNS zone identifier"
   default = "Z2XIERRF1SJEYP"

--- a/survey-runner/survey_runner.tf
+++ b/survey-runner/survey_runner.tf
@@ -26,6 +26,12 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
     value     = "${aws_security_group.survey_runner_ons_ips.id}"
   }
 
+    setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "EC2KeyName"
+    value     = "${var.elastic_beanstalk_aws_key_pair}"
+  }
+
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"

--- a/survey-runner/terraform.tfvars.example
+++ b/survey-runner/terraform.tfvars.example
@@ -1,6 +1,7 @@
 aws_access_key="XXXXXXXXXXXX"
 aws_secret_key="XXXXXXXXXXXX"
 aws_key_pair="XXXXX"
+elastic_beanstalk_aws_key_pair="XXXXX"
 ons_access_ips=[XXXXXXX, XXXXXXX]
 certificate_arn="arn:aws:iam::XXXXXXX:server-certificate/NAME"
 application_secret_key="you'll never guess it"


### PR DESCRIPTION
### What is the context of this PR?

Fixes #48 

Adding a key pair to the elastic beanstalk instances so we can SSH to them. Once we're connected to an instance we can then open a PSQL shell to the database.

This key pair is a separate configuration variable (rather than reusing the standard one). I'm also making the default value blank, as in production we do not want a key pair assigned to the elastic beanstalk instances.
### How to review
1. Checkout this branch
2. Set the new key pair terraform.vars setting (as shown in the example). This can match the other key pair variable
3. Run a terraform apply
4. Run eb deploy inside the eq-survery-runner repo (this is needed to install the postgres packages)
5. Check you can SSH to the elastic beanstalk instance
6. From there can you can open a PSQL shell (see instructions here: https://digitaleq.atlassian.net/wiki/display/EQ/Database)
- [ ] Do all commits have sensible commit messages?
- [ ] Is there documentation or is the code self-describing?
### Who worked on the PR

@warrenbailey
