### PR TITLE
Adding health check and enabling managed updates

### DIFF
--- a/survey-runner/survey_runner.tf
+++ b/survey-runner/survey_runner.tf
@@ -8,6 +8,12 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
   application = "${aws_elastic_beanstalk_application.surveyrunner.name}"
   solution_stack_name = "${var.aws_elastic_beanstalk_solution_stack_name}"
 
+  # The configuration settings for this section can be found here
+  # http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html
+  # They are listed for cloud formation but can be easily converted to terraform
+  # essentially everything is namespaced with a name and value
+
+  # settings below tell elastic beanstalk to deploy into our VPC
   setting {
     namespace = "aws:ec2:vpc"
     name      =  "VPCId"
@@ -21,33 +27,16 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
   }
 
   setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "ServiceRole"
+    value     = "aws-elasticbeanstalk-service-role"
+  }
+
+  # this setting restricts the IP range that can access elastic beanstalk
+  setting {
     namespace = "aws:elb:loadbalancer"
     name      = "SecurityGroups"
     value     = "${aws_security_group.survey_runner_ons_ips.id}"
-  }
-
-    setting {
-    namespace = "aws:autoscaling:launchconfiguration"
-    name      = "EC2KeyName"
-    value     = "${var.elastic_beanstalk_aws_key_pair}"
-  }
-
-  setting {
-    namespace = "aws:autoscaling:launchconfiguration"
-    name      = "SecurityGroups"
-    value     = "${aws_security_group.survey_runner_vpn_services_logging_auditing.id},${aws_security_group.survey_runner_ons_ips.id}"
-  }
-
-  setting {
-    namespace = "aws:ec2:vpc"
-    name = "AssociatePublicIpAddress"
-    value = "true"
-  }
-
-   setting {
-    namespace = "aws:autoscaling:launchconfiguration"
-    name      = "IamInstanceProfile"
-    value     = "${var.elastic_beanstalk_iam_role}"
   }
 
   setting {
@@ -56,6 +45,121 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
     value     = "${aws_security_group.survey_runner_ons_ips.id}"
   }
 
+  # this setting allows SSH access to the ec2 instances running elastic beanstalk (note this should be blank in prod)
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "EC2KeyName"
+    value     = "${var.elastic_beanstalk_aws_key_pair}"
+  }
+
+  # security groups for the EC2 instances
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SecurityGroups"
+    value     = "${aws_security_group.survey_runner_vpn_services_logging_auditing.id},${aws_security_group.survey_runner_ons_ips.id}"
+  }
+
+  # allows elastic beanstalk to access the outside world
+  setting {
+    namespace = "aws:ec2:vpc"
+    name = "AssociatePublicIpAddress"
+    value = "true"
+  }
+
+  # the instance role for elastic beanstalk
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = "${var.elastic_beanstalk_iam_role}"
+  }
+
+  # Number of EC2 servers to start with (min & max)
+  setting {
+    namespace = "aws:autoscaling:asg"
+    name      = "MinSize"
+    value     = "${var.eb_min_size}"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:asg"
+    name      = "MaxSize"
+    value     = "${var.eb_max_size}"
+  }
+
+  # The type of EC2 instance to launch
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "InstanceType"
+    value     = "${var.eb_instance_type}"
+  }
+
+  # The listener protocol for the Elastic beanstalk load balancer
+  setting {
+    namespace = "aws:elb:listener:443"
+    name      = "ListenerProtocol"
+    value     = "HTTPS"
+  }
+
+  # The certificate to enable SSL on the load balancers
+  setting {
+    namespace = "aws:elb:listener:443"
+    name      = "SSLCertificateId"
+    value     = "${var.certificate_arn}"
+  }
+
+  # The port the load balancer will route traffic to
+  # (LB listens on 443, terminates SSL and forwards to the EC2 instances on port 80)
+  setting {
+    namespace =  "aws:elb:listener:443"
+    name      = "InstancePort"
+    value = "80"
+  }
+
+  setting {
+    namespace  = "aws:elb:listener:443"
+    name       = "InstanceProtocol"
+    value      = "HTTP"
+  }
+
+  # Healthcheck settings for elastic beanstalk
+  setting {
+    namespace = "aws:elasticbeanstalk:application"
+    name      = "Application Healthcheck URL"
+    value     = "/status"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:healthreporting:system"
+    name      = "SystemType"
+    value     = "enhanced"
+  }
+
+  # Managed updates setting, basically all EC2 instances are refreshed and updated weekly on Tuesday at 3am
+  setting {
+    namespace = "aws:elasticbeanstalk:managedactions"
+    name      = "ManagedActionsEnabled"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:managedactions"
+    name      = "PreferredStartTime"
+    value     = "Tue:03:00"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:managedactions:platformupdate"
+    name      = "UpdateLevel"
+    value     = "minor"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:managedactions:platformupdate"
+    name      = "InstanceRefreshEnabled"
+    value     = "true"
+  }
+
+  # Survey Runner Application Specific Environment variables
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_SECRET_KEY"
@@ -93,24 +197,6 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
   }
 
   setting {
-    namespace = "aws:autoscaling:asg"
-    name      = "MaxSize"
-    value     = "${var.eb_max_size}"
-  }
-
-  setting {
-    namespace = "aws:autoscaling:asg"
-    name      = "MinSize"
-    value     = "${var.eb_min_size}"
-  }
-
-  setting {
-    namespace = "aws:autoscaling:launchconfiguration"
-    name      = "InstanceType"
-    value     = "${var.eb_instance_type}"
-  }
-
-  setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_LOG_LEVEL"
     value     = "${var.eq_sr_log_level}"
@@ -138,30 +224,6 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_UA_ID"
     value     = "${var.google_analytics_code}"
-  }
-
-  setting {
-    namespace = "aws:elb:listener:443"
-    name      = "ListenerProtocol"
-    value     = "HTTPS"
-  }
-
-  setting {
-    namespace = "aws:elb:listener:443"
-    name      = "SSLCertificateId"
-    value     = "${var.certificate_arn}"
-  }
-
-  setting {
-    namespace =  "aws:elb:listener:443"
-    name      = "InstancePort"
-    value = "80"
-  }
-
-  setting {
-    namespace  = "aws:elb:listener:443"
-    name       = "InstanceProtocol"
-    value      = "HTTP"
   }
 
   setting {
@@ -194,7 +256,6 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
     value     = "postgresql://${var.database_user}:${var.database_password}@${aws_db_instance.survey_runner_database.address}:${aws_db_instance.survey_runner_database.port}/${aws_db_instance.survey_runner_database.name}"
   }
 }
-
 
 resource "aws_route53_record" "survey_runner" {
   zone_id = "${var.dns_zone_id}"

--- a/survey-runner/survey_runner.tf
+++ b/survey-runner/survey_runner.tf
@@ -141,10 +141,11 @@ resource "aws_elastic_beanstalk_environment" "sr_prime" {
     value     = "true"
   }
 
+  # time is UTC
   setting {
     namespace = "aws:elasticbeanstalk:managedactions"
     name      = "PreferredStartTime"
-    value     = "Tue:03:00"
+    value     = "Tue:02:00"
   }
 
   setting {


### PR DESCRIPTION
### What is the context of this PR?

Fixes #50 
1. Adding a healthcheck URL for elastic beanstalk
2. Enabling enhanced health checking for the Survey Runner
3. Enabling managed updates weekly on Tuesdays at 3am
### How to review
1. Ensure the aws-elasticbeanstalk-service-role exists with the following roles: 
   ![screen shot 2016-08-22 at 14 41 27](https://cloud.githubusercontent.com/assets/14093825/17856688/9c317618-6876-11e6-84d6-3145d03afac7.png)
2. Run a terraform apply for **both** survey runner and author
3. Confirm the health check url is set, enhanced healthcheck is enabled and managed updates is also enabled  **on both server runner and author**
- [ ] Do all commits have sensible commit messages?
- [ ] Is there documentation or is the code self-describing?
### Who worked on the PR

@warrenbailey
