### PR TITLE
Update README file with fixed version number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You may also need to explicitly tell Ansible to perform non-host key checking:
 
 Make sure you've installed all the roles from eq-messaging
 
- `sudo ansible-galaxy install alexeymedvedchikov.rabbitmq`
+ `sudo ansible-galaxy install alexeymedvedchikov.rabbitmq,v0.0.2`
 
  `sudo ansible-galaxy install jnv.unattended-upgrades`
 


### PR DESCRIPTION
### What is the context of this PR?
Updated the installation instructions for the `alexeymedvedchikov.rabbitmq` to use a fixed version number.

This helps ensure that the Ansible role is fixed to a known 'good' version that works with the eQ Terraform scripts.
When no version is specified, the latest version of the Ansible role is pulled down from GitHub.
Recent changes to this Ansible role broke the Terraform scripts.
Until the Terraform scripts are re-visited and updated, reverting to a previous version of the Ansible role is necessary to ensure that the scripts continue to run without error.

### How to review
Ensure that you are able to run the eQ terraform as per the updated README file to successfully build the RabbitMQ EC2 instances in AWS.