### PR TITLE
Update syntax to be compatible with Terraform v0.8.4

### DIFF
--- a/survey-runner/cloudwatch.tf
+++ b/survey-runner/cloudwatch.tf
@@ -24,8 +24,9 @@ resource "aws_cloudwatch_metric_alarm" "rabbitmq2_cluster_status" {
     alarm_actions = ["${var.cloudwatch_alarm_arn}"]
 }
 
-resource "aws_cloudwatch_metric_alarm" "rabbitmq1_cpu" {
-    alarm_name = "${var.env}-rabbitmq1-cpu-alert"
+resource "aws_cloudwatch_metric_alarm" "rabbitmq_cpu" {
+    count = 2
+    alarm_name = "${var.env}-rabbitmq${count.index + 1}-cpu-alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "CPUUtilization"
@@ -35,25 +36,12 @@ resource "aws_cloudwatch_metric_alarm" "rabbitmq1_cpu" {
     threshold ="80"
     alarm_description = "Alert generated if over 80% CPU usage"
     alarm_actions = ["${var.cloudwatch_alarm_arn}"]
-    dimensions { "InstanceId"="${aws_instance.rabbitmq.0.id}"}
+    dimensions { "InstanceId"="${element(aws_instance.rabbitmq.*.id,count.index)}" }
 }
 
-resource "aws_cloudwatch_metric_alarm" "rabbitmq2_cpu" {
-    alarm_name = "${var.env}-rabbitmq2-cpu-alert"
-    evaluation_periods = "1"
-    comparison_operator = "GreaterThanOrEqualToThreshold"
-    metric_name = "CPUUtilization"
-    namespace ="AWS/EC2"
-    period ="300"
-    statistic ="Average"
-    threshold ="80"
-    alarm_description = "Alert generated if over 80% CPU usage"
-    alarm_actions = ["${var.cloudwatch_alarm_arn}"]
-    dimensions { "InstanceId"="${aws_instance.rabbitmq.1.id}"}
-}
-
-resource "aws_cloudwatch_metric_alarm" "rabbitmq1_status" {
-    alarm_name = "${var.env}-rabbitmq-1-status-alert"
+resource "aws_cloudwatch_metric_alarm" "rabbitmq_status" {
+    count = 2
+    alarm_name = "${var.env}-rabbitmq-${count.index + 1}-status-alert"
     evaluation_periods = "1"
     comparison_operator = "GreaterThanOrEqualToThreshold"
     metric_name = "StatusCheckFailed"
@@ -63,21 +51,7 @@ resource "aws_cloudwatch_metric_alarm" "rabbitmq1_status" {
     threshold ="1"
     alarm_description = "Alert generated if status changes to failure"
     alarm_actions = ["${var.cloudwatch_alarm_arn}"]
-    dimensions { "InstanceId"="${aws_instance.rabbitmq.0.id}"}
-}
-
-resource "aws_cloudwatch_metric_alarm" "rabbitmq2_status" {
-    alarm_name = "${var.env}-rabbitmq2-status-alert"
-    evaluation_periods = "1"
-    comparison_operator = "GreaterThanOrEqualToThreshold"
-    metric_name = "StatusCheckFailed"
-    namespace ="AWS/EC2"
-    period ="300"
-    statistic ="Maximum"
-    threshold ="1"
-    alarm_description = "Alert generated if status changes to failure"
-    alarm_actions = ["${var.cloudwatch_alarm_arn}"]
-    dimensions { "InstanceId"="${aws_instance.rabbitmq.1.id}"}
+    dimensions { "InstanceId"="${element(aws_instance.rabbitmq.*.id,count.index)}" }
 }
 
 resource "aws_cloudwatch_metric_alarm" "database_storage_alert" {

--- a/survey-runner/message_queue.tf
+++ b/survey-runner/message_queue.tf
@@ -183,7 +183,7 @@ resource "null_resource" "aws_hosts" {
 }
 
 resource "null_resource" "ansible" {
-    depends_on = ["null_resource.aws_hosts", "aws_route53_record.rabbitmq1", "aws_route53_record.rabbitmq2"]
+    depends_on = ["null_resource.aws_hosts", "aws_route53_record.rabbitmq"]
 
     provisioner "local-exec" {
       command = "rm -rf tmp"
@@ -201,18 +201,11 @@ resource "null_resource" "ansible" {
     }
 }
 
-resource "aws_route53_record" "rabbitmq1" {
+resource "aws_route53_record" "rabbitmq" {
+  count = 2
   zone_id = "${var.dns_zone_id}"
-  name = "${var.env}-rabbitmq1.${var.dns_zone_name}"
+  name = "${var.env}-rabbitmq${count.index + 1}.${var.dns_zone_name}"
   type = "A"
   ttl = "60"
-  records = ["${aws_instance.rabbitmq.0.public_ip}"]
-}
-
-resource "aws_route53_record" "rabbitmq2" {
-  zone_id = "${var.dns_zone_id}"
-  name = "${var.env}-rabbitmq2.${var.dns_zone_name}"
-  type = "A"
-  ttl = "60"
-  records = ["${aws_instance.rabbitmq.1.public_ip}"]
+  records = ["${element(aws_instance.rabbitmq.*.public_ip,count.index)}"]
 }


### PR DESCRIPTION
### What is the context of this PR?
Updated scripts to be compatible with Terraform v0.8.4

### How to review
- Ensure you are running Terraform v0.8.4
- Run the scripts 
- Ensure CloudWatch metric alarms are set up for `CPUUtilization` and `StatusCheckFailed` for both RabbitMQ servers and ensure they point to the right ec2 instance ids
 - Ensure Route53 records are created for each RabbitMQ server and they point to the correct IPs
- Deploy survey-runner and check it works
