### PR TITLE
Enable cloudwatch logging

### DIFF
--- a/survey-runner-application/global_vars.tf
+++ b/survey-runner-application/global_vars.tf
@@ -55,7 +55,7 @@ variable "dns_zone_name" {
 # EB Configuration
 variable "aws_elastic_beanstalk_solution_stack_name" {
   description = "Elastic Beanstalk Amazon Linux version"
-  default     = "64bit Amazon Linux 2016.03 v2.1.0 running Python 3.4"
+  default     = "64bit Amazon Linux 2016.09 v2.3.1 running Python 3.4"
 }
 
 variable "eb_instance_type" {
@@ -105,11 +105,6 @@ variable "aws_default_region" {
 variable "eq_sr_log_level" {
   description = "The Survey Runner logging level (One of ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'])"
   default     = "ERROR"
-}
-
-variable "cloudwatch_logging" {
-  description = "Enable Cloudwatch logging"
-  default     = "True"
 }
 
 variable "survey_runner_env" {

--- a/survey-runner-application/survey_runner.tf
+++ b/survey-runner-application/survey_runner.tf
@@ -211,11 +211,6 @@ resource "aws_elastic_beanstalk_environment" "survey_runner_prime" {
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "EQ_CLOUDWATCH_LOGGING"
-    value     = "${var.cloudwatch_logging}"
-  }
-  setting {
-    namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_UA_ID"
     value     = "${var.google_analytics_code}"
   }
@@ -248,6 +243,16 @@ resource "aws_elastic_beanstalk_environment" "survey_runner_prime" {
     namespace = "aws:elasticbeanstalk:container:python"
     name      = "NumThreads"
     value     = "${var.wsgi_number_of_threads}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+    name      = "StreamLogs"
+    value     = "true"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+    name      = "RetentionInDays"
+    value     = "30"
   }
 }
 

--- a/survey-runner-application/terraform.tfvars.example
+++ b/survey-runner-application/terraform.tfvars.example
@@ -11,7 +11,6 @@ certificate_arn="arn:aws:iam::XXXXXXX:server-certificate/NAME"
 # Environment variables
 application_secret_key="you'll never guess it"
 eq_sr_log_level="DEBUG"
-cloudwatch_logging="False"
 google_analytics_code=""
 dev_mode="True"
 


### PR DESCRIPTION
### What is the context of this PR?
Enable Cloudwatch logging from elastic beanstalk

### How to review
Are logs available in cloud watch
eg.
/aws/elasticbeanstalk/jonshaw-prime/var/log/httpd/error_log