### PR TITLE
Make Python WSGI settings configurable

### DIFF
--- a/survey-runner-application/global_vars.tf
+++ b/survey-runner-application/global_vars.tf
@@ -73,6 +73,16 @@ variable "eb_max_size" {
   default     = "2"
 }
 
+variable "wsgi_number_of_processes" {
+  description = "The number of daemon processes that should be started for the process group when running WSGI applications"
+  default     = 1
+}
+
+variable "wsgi_number_of_threads" {
+  description = "The number of threads to be created to handle requests in each daemon process within the process group when running WSGI applications"
+  default     = 15
+}
+
 variable "elastic_beanstalk_aws_key_pair" {
   description = "Amazon Web Service Key Pair for use by elastic beanstalk - in production this value should be empty"
   default     = ""

--- a/survey-runner-application/survey_runner.tf
+++ b/survey-runner-application/survey_runner.tf
@@ -219,6 +219,16 @@ resource "aws_elastic_beanstalk_environment" "survey_runner_prime" {
     name      = "EQ_SERVER_SIDE_STORAGE_DATABASE_URL"
     value     = "postgresql://${var.database_user}:${var.database_password}@${var.database_address}:${var.database_port}/${var.database_name}"
   }
+  setting {
+    namespace = "aws:elasticbeanstalk:container:python"
+    name      = "NumProcesses"
+    value     = "${var.wsgi_number_of_processes}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:container:python"
+    name      = "NumThreads"
+    value     = "${var.wsgi_number_of_threads}"
+  }
 }
 
 resource "aws_route53_record" "survey_runner" {


### PR DESCRIPTION
### What is the context of this PR?

The default Elastic Beanstalk settings of 1 process and 15 threads is not very efficient when the size of the instances is increased. This pull request makes the number of processes and number of threads configurable so they can be changed per environment.

### How to review

Customise the `wsgi_number_of_processes` and `wsgi_number_of_threads` variables in your terraform.tfvars file for survey-runner-application and verify the Elastic Beanstalk configuration has been updated (Configuration > Software Configuration) e.g.

![image](https://cloud.githubusercontent.com/assets/1754822/23125699/fda0d51e-f76a-11e6-9915-4811feb9f71a.png)
