### PR TITLE
Enable immutable application deployments and rolling config updates

### DIFF
--- a/survey-runner-application/survey_runner.tf
+++ b/survey-runner-application/survey_runner.tf
@@ -45,6 +45,26 @@ resource "aws_elastic_beanstalk_environment" "survey_runner_prime" {
     name      = "ServiceRole"
     value     = "aws-elasticbeanstalk-service-role"
   }
+
+  # Application Deployments
+  setting {
+    namespace = "aws:elasticbeanstalk:command"
+    name      = "DeploymentPolicy"
+    value     = "Immutable"
+  }
+
+  # Configuration Updates
+  setting {
+    namespace = "aws:autoscaling:updatepolicy:rollingupdate"
+    name      = "RollingUpdateEnabled"
+    value     = "true"
+  }
+  setting {
+    namespace = "aws:autoscaling:updatepolicy:rollingupdate"
+    name      = "RollingUpdateType"
+    value     = "Immutable"
+  }
+
   # This setting restricts the IP range that can access elastic beanstalk
   setting {
     namespace = "aws:elb:loadbalancer"


### PR DESCRIPTION
### What is the context of this PR?
Enables immutable application deployments and rolling config updates. This ensures we get new ec2 instances on each application deployment, removing issues we've had with config from a previous deployment (Apache single threaded WSGI) not being removed.

### How to review
Check out and verify that the Configuration > Updates and Deployments page looks like this (Immutable Deployments and Rolling based on Health updates):

![image](https://cloud.githubusercontent.com/assets/1754822/23127822/51607764-f774-11e6-87b2-c8b334c1e5bb.png)
