### PR TITLE
Make database version configurable

### DIFF
--- a/survey-runner-database/database.tf
+++ b/survey-runner-database/database.tf
@@ -26,21 +26,22 @@ resource "aws_db_subnet_group" "survey_runner_rds" {
 }
 
 resource "aws_db_instance" "survey_runner_database" {
-  allocated_storage       = "${var.database_allocated_storage}"
-  identifier              = "${var.env}-digitaleqrds"
-  engine                  = "postgres"
-  engine_version          = "9.4.5"
-  instance_class          = "${var.database_instance_class}"
-  name                    = "${var.database_name}"
-  username                = "${var.database_user}"
-  password                = "${var.database_password}"
-  multi_az                = "${var.multi_az}"
-  publicly_accessible     = false
-  backup_retention_period = "${var.backup_retention_period}"
-  db_subnet_group_name    = "${aws_db_subnet_group.survey_runner_rds.name}"
-  vpc_security_group_ids  = ["${aws_security_group.survey_runner_rds_access.id}"]
-  storage_type            = "gp2"
-  apply_immediately       = "${var.database_apply_immediately}"
+  allocated_storage           = "${var.database_allocated_storage}"
+  identifier                  = "${var.env}-digitaleqrds"
+  engine                      = "postgres"
+  engine_version              = "${var.database_engine_version}"
+  allow_major_version_upgrade = "${var.allow_major_version_upgrade}"
+  instance_class              = "${var.database_instance_class}"
+  name                        = "${var.database_name}"
+  username                    = "${var.database_user}"
+  password                    = "${var.database_password}"
+  multi_az                    = "${var.multi_az}"
+  publicly_accessible         = false
+  backup_retention_period     = "${var.backup_retention_period}"
+  db_subnet_group_name        = "${aws_db_subnet_group.survey_runner_rds.name}"
+  vpc_security_group_ids      = ["${aws_security_group.survey_runner_rds_access.id}"]
+  storage_type                = "gp2"
+  apply_immediately           = "${var.database_apply_immediately}"
 
   tags {
     Name        = "${var.env}-db-instance"

--- a/survey-runner-database/global_vars.tf
+++ b/survey-runner-database/global_vars.tf
@@ -35,8 +35,18 @@ variable "database_cidrs" {
 }
 
 variable "database_allocated_storage" {
-    description = "The allocated storage for the database (in GB)"
-    default     = 100
+  description = "The allocated storage for the database (in GB)"
+  default     = 100
+}
+
+variable "database_engine_version" {
+  description = "The Postgres database engine version"
+  default     = "9.4.9"
+}
+
+variable "allow_major_version_upgrade" {
+  description = "Allow major database version upgrades e.g. 9.4.x to 9.5.x"
+  default     = false
 }
 
 variable "database_instance_class" {
@@ -50,8 +60,8 @@ variable "multi_az" {
 }
 
 variable "backup_retention_period" {
-    description = "How many days database backup to keep"
-    default     = 7
+  description = "How many days database backup to keep"
+  default     = 7
 }
 
 variable "database_name" {
@@ -76,6 +86,5 @@ variable "cloudwatch_alarm_arn" {
 
 variable "database_apply_immediately" {
   description = "Apply changes to the database immediately and not during next maintenance window"
-  default     = true
-
+  default     = false
 }

--- a/survey-runner-database/terraform.tfvars.example
+++ b/survey-runner-database/terraform.tfvars.example
@@ -5,5 +5,6 @@ database_cidrs=["10.30.20.96/28","10.30.20.112/28"]
 
 multi_az = false
 backup_retention_period = 0
+database_allocated_storage = 10
 
 cloudwatch_alarm_arn="arn:aws:sns:eu-west-1:XXXXXX:slack-alarm"


### PR DESCRIPTION
### What is the context of this PR?
Makes the database version configurable. The default has been set to 9.4.9 as we use 9.4.x in production. 

### How to review
Run database Terraform and verify database version changes are applied in AWS
