### PR TITLE
Make load balancer configurable (internal/external)

### DIFF
--- a/survey-runner-application/global_vars.tf
+++ b/survey-runner-application/global_vars.tf
@@ -18,6 +18,11 @@ variable "vpc_cidr_block" {
   description = "CIDR block of the VPC"
 }
 
+variable "vpc_peer_cidr_block" {
+  description = "The CIDR block of the peered VPC, optional"
+  default     = ""
+}
+
 variable "public_subnet_ids" {
   description = "The IDs of the public subnets for the external ELBs"
 }
@@ -29,6 +34,11 @@ variable "private_route_table_ids" {
 variable "application_cidrs" {
   type        = "list"
   description = "CIDR blocks for application subnets"
+}
+
+variable "use_internal_elb" {
+  description = "Set to true to use an internal load balancer"
+  default     = false
 }
 
 variable "availability_zones" {


### PR DESCRIPTION
Makes the load balancer configurable to allow access via a WAF where one exists and access from the internet where one doesn't.

Currently the WAF is in the corporate VPC and is only available in pre-production and production environments.

### How to review
- Run the Terraform without making any changes to your existing tfvars, it should work as it did before
- Add `use_internal_elb=true` and `vpc_peer_cidr_block="0.0.0.0/0"` to your tfvars file and verify:
  - The load balancer is now internal
  - The security group allows access from 0.0.0.0/0 on port 80
  - Without something (like the WAF) to route access from the internet, you won't be able to access the application