### PR TITLE
Change default application log level to info

### DIFF
--- a/survey-runner-application/global_vars.tf
+++ b/survey-runner-application/global_vars.tf
@@ -112,9 +112,9 @@ variable "aws_default_region" {
   default     = "eu-west-1"
 }
 
-variable "eq_sr_log_level" {
+variable "eq_log_level" {
   description = "The Survey Runner logging level (One of ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'])"
-  default     = "ERROR"
+  default     = "INFO"
 }
 
 variable "survey_runner_env" {

--- a/survey-runner-application/survey_runner.tf
+++ b/survey-runner-application/survey_runner.tf
@@ -199,7 +199,7 @@ resource "aws_elastic_beanstalk_environment" "survey_runner_prime" {
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "EQ_LOG_LEVEL"
-    value     = "${var.eq_sr_log_level}"
+    value     = "${var.eq_log_level}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"

--- a/survey-runner-application/terraform.tfvars.example
+++ b/survey-runner-application/terraform.tfvars.example
@@ -10,7 +10,7 @@ certificate_arn="arn:aws:iam::XXXXXXX:server-certificate/NAME"
 
 # Environment variables
 application_secret_key="you'll never guess it"
-eq_sr_log_level="DEBUG"
+eq_log_level="DEBUG"
 google_analytics_code=""
 dev_mode="True"
 


### PR DESCRIPTION
Changes the default application log level to `INFO`. This is the log level we use in production now as the information it provides is used across the data collection platform to track a respondents journey and generate metrics for dashboards.

### How to review
- Remove any setting of `eq_sr_log_level` from your application terraform.tfvars file
- Deploy survey runner
- Verify that `INFO` log events appear in the logs