### PR TITLE
Add ability to restore RDS instance from snapshot.

### DIFF
--- a/survey-runner-database/database.tf
+++ b/survey-runner-database/database.tf
@@ -32,7 +32,7 @@ resource "aws_db_instance" "survey_runner_database" {
   engine_version              = "${var.database_engine_version}"
   allow_major_version_upgrade = "${var.allow_major_version_upgrade}"
   instance_class              = "${var.database_instance_class}"
-  name                        = "${var.database_name}"
+  name                        = "${var.snapshot_identifier == "" ? var.database_name : ""}"
   username                    = "${var.database_user}"
   password                    = "${var.database_password}"
   multi_az                    = "${var.multi_az}"
@@ -42,6 +42,8 @@ resource "aws_db_instance" "survey_runner_database" {
   vpc_security_group_ids      = ["${aws_security_group.survey_runner_rds_access.id}"]
   storage_type                = "gp2"
   apply_immediately           = "${var.database_apply_immediately}"
+  snapshot_identifier         = "${var.snapshot_identifier}"
+  skip_final_snapshot         = true
 
   tags {
     Name        = "${var.env}-db-instance"

--- a/survey-runner-database/global_vars.tf
+++ b/survey-runner-database/global_vars.tf
@@ -93,3 +93,7 @@ variable "database_free_storage_alert_level" {
   description = "The level at which to alert about lack of free storage (GB)"
   default     = 5
 }
+
+variable "snapshot_identifier" {
+  default     = ""
+}


### PR DESCRIPTION
### What is the context of this PR?
A recent OAT test identified the need to have some automated mechanism to restore RDS databases instances from a point in time Snapshot.
This PR makes a change to the eQ terraform scripts such that an RDS instance can be created from a Snapshot identifier.

This has been tested against the development environment in AWS.
The below scenario has been performed a few times, in addition, I have also repeated the test to restore back to an empty database, this worked, although the Elastic Beanstalk instances had to be restarted for the application to become available again.

### How to review
1. Build a new development environment.
2. Start filling in some survey data.
3. Create a snapshot of the RDS instance associated with your development environment.
4. Give it a name, you will need to refer to this name in Step 6.
5. Run the `./run-terraform.sh destroy` script for the database.
6. Amend the `snapshot_identifier` variable so that it has the name specified in Step 4.
7. Run the `./run-terraform.sh apply` script for the database.
8. After the database has been re-built, confirm that the application works and that data entered previously was restored.

