### PR TITLE
Enable cross zone load balancing for Elastic Beanstalk

### DIFF
--- a/survey-runner-application/survey_runner.tf
+++ b/survey-runner-application/survey_runner.tf
@@ -74,6 +74,11 @@ resource "aws_elastic_beanstalk_environment" "survey_runner_prime" {
     name      = "ManagedSecurityGroup"
     value     = "${aws_security_group.survey_runner_access.id}"
   }
+  setting {
+    namespace = "aws:elb:loadbalancer"
+    name      = "CrossZone"
+    value     = "true"
+  }
   # this setting allows SSH access to the ec2 instances running elastic beanstalk (note this should be blank in prod)
   setting {
     namespace = "aws:autoscaling:launchconfiguration"


### PR DESCRIPTION
Cross-zone load balancing reduces the need to maintain equivalent numbers of instances in each enabled Availability Zone, and improves your application's ability to handle the loss of one or more instances

### Acceptance Criteria
 EB uses cross-zone load balancing

### How to verify
In you Elastic beanstalk environment under the configuration section.
Under the Network Tier in the Load Balancing box, it should read "Cross zone load balancing is enabled"
