### PR TITLE
Add Ansible requirements to configuration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,12 @@ Terraform project that creates the infrastructure for the EQ project alpha.
 The following programs must be installed:
 
 1. Git
-1. Ansible
-1. AWS CLI
+1. Ansible - `brew install ansible`
+1. AWS CLI - `brew install awscli`
 
-You may also need to explicitly tell Ansible to perform non-host key checking:
+Install roles required by [eq-messaging](https://github.com/ONSdigital/eq-messaging):
 
-  `export ANSIBLE_HOST_KEY_CHECKING=False`
-
-Make sure you've installed all the roles from eq-messaging
-
- `sudo ansible-galaxy install git+https://github.com/alexey-medvedchikov/ansible-rabbitmq.git,3e3531c0a12e2d5c597f2f45d1fdf8e449730574`
-
- `sudo ansible-galaxy install jnv.unattended-upgrades`
-
-Also the pre-prod.pem key must exist in this directory.
+ `ansible-galaxy install -f -r survey-runner-queue/ansible-requirements.yml`
 
 ## Setting up your AWS credentials
 
@@ -32,71 +24,36 @@ Also the pre-prod.pem key must exist in this directory.
 
 ## Setting up Terraform
 
-1. Install terraform(terraform.io) and add the binary to your shell path. If you are using Homebrew:
+1. Install [Terraform](https://terraform.io) - `brew install terraform`
 
-```
-brew install terraform
-```
+1. Generate an SSH key pair in AWS with a unique name (e.g. your name) and save it to the top level (eq-terraform) directory
 
-1. Generate ssh key pair in AWS for your AWS user
+1. Restrict access to the key - `chmod 400 mykey.pem`
 
-1. Download and restrict access by executing:
+1. Copy `terraform.tfvars.example` to `terraform.tfvars`. You'll need to change all values to match your requirements, including the AWS credentials you set up previously. Ask another developer for any values you don't know.
 
-```
-chmod 400 mykey.pem
-```
+## Running Terraform
 
-1. Move the ssh key to `eq-terraform`
-
-1. Copy `terraform.tfvars.example` to `terraform.tfvars`. You'll need to change all values to match your requirements, including the AWS credentials you set up previously.
-
-1. To deploy survey-runner:
-
-  - Run `terraform get` to import the different modules
-  
-  - Run `terraform plan` to check the output of terraform
-
-  - Run `terraform apply` to create your infrastructure environment
-
-  - Run `terraform destroy` to destroy your infrastructure environment
-
-Note. If using a named profile ensure you have set the profile e.g. `export AWS_DEFAULT_PROFILE=ons`
-
-1. To deploy author:
-
-  - cd into author
+  - Run `terraform init` to import the different modules and set up remote state. When asked to provide a name for the state file choose the same name as the `env` value in your `terraform.tfvars`
 
   - Run `terraform plan` to check the output of terraform
 
   - Run `terraform apply` to create your infrastructure environment
 
   - Run `terraform destroy` to destroy your infrastructure environment
-
-## Deploying the application
-The terraform scripts will only create your elastic beanstalk environment and a holding page for your application. To
-deploy either the survey runner or the author follow these steps:
-1. eb init  (select your newly created environment)
-1. eb list (will give you the environment name)
-1. eb deploy <your-env-name>
 
 ## Alerting
-A webhook will need to be created for a new integration via https://api.slack.com/incoming-webhooks
-Alternatively, your team may already have a webhook url created to send messages to your slack.  
 
-You will need to create a slack channel with the name, `eq-<your-env-name>-alerts`
+A webhook will need to be created for a new integration via https://api.slack.com/incoming-webhooks. Alternatively, your team may already have a webhook url configured to send messages to your slack.  
 
-Eg. eq-preprod-alerts
+Create a slack channel with the name `eq-<your-env-name>-alerts`, for example `eq-preprod-alerts`
 
-## Additional security
+## Additional Security
 
-To increase the security of the system, remove the security group `"provision-allow-ssh-REMOVE`
-from the rabbitmq machines to block their SSH access. This is retained to allow provisioning
-via ansible. In future we may migrate to a bastion machine to provision, which could
-be then replicated locally via docker / VM bastion.
+Once Terraform has completed successfully, remove the security group `provision-allow-ssh-REMOVE` from the RabbitMQ machines to block their SSH access. This is used to allow provisioning via Ansible.
 
 ## Troubleshooting
 
 1. If your build fails make sure the tmp directory has been deleted.
 1. If the build stalls on the ssh step waiting for user input set the following in your ~/.ssh/config file
-    `StrictHostKeyChecking no`
     `UserKnownHostsFile /dev/null`

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,1 @@
+survey-runner-queue/ansible.cfg

--- a/survey-runner-queue/ansible-requirements.yml
+++ b/survey-runner-queue/ansible-requirements.yml
@@ -1,0 +1,5 @@
+- src: https://github.com/alexey-medvedchikov/ansible-rabbitmq.git
+  version: 3e3531c0a12e2d5c597f2f45d1fdf8e449730574
+  name: alexeymedvedchikov.rabbitmq
+- src: jnv.unattended-upgrades
+  version: v1.3.0


### PR DESCRIPTION
### What is the context of this PR?
The previous approach of installing the `alexey-medvedchikov` role with a fixed git commit didn't work as expected. The role was installed, but as a role named `ansible-rabbitmq`, which then wasn't detected by Ansible. Installing the role via a requirements YAML gives the chance to override the role name on installation, and also means the roles and versions are in configuration rather than just the README.

- Added an ansible requirements file to capture what ansible roles are required and what versions in configuration
- Symlinked ansible.cfg from the queue module to the eq-terraform directory so it is read when running Terraform from that directory
- Updated README

### How to review
- Review README content
- Follow the instructions and check everything works

### Notes
You may need to remove existing ansible roles before installing new ones