### PR TITLE
eq snapshot jenkins server initial files

### DIFF
--- a/jenkins-snapshot/developer_defaults.tf
+++ b/jenkins-snapshot/developer_defaults.tf
@@ -1,0 +1,47 @@
+variable "env" {
+  description = "The environment you wish to use"
+}
+
+variable "aws_secret_key" {
+  description = "Amazon Web Service Secret Key"
+}
+
+variable "aws_access_key" {
+  description = "Amazon Web Service Access Key"
+}
+
+# DNS
+variable "dns_zone_id" {
+  description = "Amazon Route53 DNS zone identifier"
+}
+
+variable "dns_zone_name" {
+  description = "Amazon Route53 DNS zone name"
+  default     = "dev.eq.ons.digital"
+}
+
+// ECS
+variable "ecs_instance_type" {
+  description = "ECS Instance Type"
+  default     = "t2.micro"
+}
+
+  variable "jenkins_snapshot_retention_days" {
+  description = "How many days to keep backup of queues"
+  default     = 1
+}
+
+variable "backup_retention_period" {
+  description = "How many days database backup to keep"
+  default     = 0
+}
+
+variable "aws_default_region" {
+  description = "The default region for AWS Services"
+  default     = "eu-west-1"
+}
+
+variable "jenkins_snapshot_cron"{
+    description = "Timescale for when the job is to be run"
+    default = "27 * * * ? *"
+}

--- a/jenkins-snapshot/ebs.tf
+++ b/jenkins-snapshot/ebs.tf
@@ -1,0 +1,9 @@
+module "ebs_bckup" {
+  source = "github.com/ONSdigital/ebs_bckup?ref=f9b4e8272fe23a6ec30f40755a349e5f0f83c17d"
+  EC2_INSTANCE_TAG = "${var.env}-jenkins"
+  RETENTION_DAYS   = "${var.jenkins_snapshot_retention_days}"
+  unique_name      = "berian-test"
+  stack_prefix     = "${var.env}"
+  cron_expression  = "${var.jenkins_snapshot_cron}"
+  regions          = ["${var.aws_default_region}"]
+}

--- a/jenkins-snapshot/example.tf
+++ b/jenkins-snapshot/example.tf
@@ -1,0 +1,6 @@
+provider "aws" {
+  access_key = ""
+  secret_key = ""
+  region     = "eu-west-1"
+}
+

--- a/jenkins-snapshot/run-terraform.sh
+++ b/jenkins-snapshot/run-terraform.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ -z "$AWS_ENVIRONMENT_NAME" ]; then
+    echo "Need to set AWS_ENVIRONMENT_NAME environment variable e.g. export AWS_ENVIRONMENT_NAME=preprod"
+    exit 1
+fi
+
+export ANSIBLE_HOST_KEY_CHECKING=False
+action=$1
+
+if [ $action != "apply" ] && [ $action != "plan" ] && [ $action != "destroy" ]; then
+    echo "You must provide an action (apply/plan/destroy) e.g. ./run-terraform.sh plan"
+    exit 1
+fi
+
+terraform $action -var "env=${AWS_ENVIRONMENT_NAME}" 
+
+

--- a/jenkins-snapshot/terraform.tfvars.examples
+++ b/jenkins-snapshot/terraform.tfvars.examples
@@ -1,0 +1,10 @@
+env=""
+aws_access_key=""
+aws_secret_key=""
+aws_key_pair = ""
+
+dns_zone_id=""
+
+ons_access_ips=""
+certificate_arn=""
+slack_webhook_path = ""


### PR DESCRIPTION
### What is the context of this PR?
Added new directory jerkins-snapshot, which is intended to snapshot the jenkins-preprod instance
### How to review
create a ec2 server instance (nano is fine) called jenkins-preprod-eqdevelopment.
In eq-terraform, cd to jenkins-snaphot
run terraform init or terraform get to bring in the ebs_bckup module.
amend the developer_defaults.tf file to change the minutes in the cron variable (I add about 3 - 4 minutes to the current time to allow time for the lambda function to be built)
You'll need to supply the was_instance key the was secret key and the zone which is "dev.eq.ons.digital"

a snapshot should be created.

I'm aware that I'll probably need to amend the name of the instance to either jenkins-${var.env} or even hard code to jenkins-preprod for the real thing, but I'm looking to see I haven't missed anything else. Once this is passed, I'll create the jenkins job .

### Who worked on the PR



