### PR TITLE
Fixed ansible run issue when hostname has trailing dot

### DIFF
--- a/survey-runner-queue/ansible.cfg
+++ b/survey-runner-queue/ansible.cfg
@@ -1,2 +1,0 @@
-[ssh_connection]
-host_key_checking = False

--- a/survey-runner-queue/ansible.cfg
+++ b/survey-runner-queue/ansible.cfg
@@ -1,3 +1,2 @@
 [ssh_connection]
-control_path = %(directory)s/%%h-%%p-%%r
 host_key_checking = False

--- a/survey-runner-queue/cloudwatch.tf
+++ b/survey-runner-queue/cloudwatch.tf
@@ -11,6 +11,7 @@ resource "aws_cloudwatch_metric_alarm" "rabbitmq_cluster_status" {
   alarm_description         = "${var.env} rabbit mq ${count.index + 1} reporting cluster paritions"
   alarm_actions             = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
   insufficient_data_actions = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
+  treat_missing_data        = "breaching"
 }
 
 resource "aws_cloudwatch_metric_alarm" "rabbitmq_cpu" {
@@ -25,6 +26,7 @@ resource "aws_cloudwatch_metric_alarm" "rabbitmq_cpu" {
   threshold           = "80"
   alarm_description   = "Alert generated if over 80% CPU usage"
   alarm_actions       = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
+  treat_missing_data  = "breaching"
 
   dimensions {
     "InstanceId" = "${element(aws_instance.rabbitmq.*.id,count.index)}"
@@ -44,6 +46,7 @@ resource "aws_cloudwatch_metric_alarm" "rabbitmq_status" {
   alarm_description         = "Alert generated if status changes to failure"
   alarm_actions             = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
   insufficient_data_actions = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
+  treat_missing_data        = "breaching"
 
   dimensions {
     "InstanceId" = "${element(aws_instance.rabbitmq.*.id,count.index)}"

--- a/survey-runner-queue/cloudwatch.tf
+++ b/survey-runner-queue/cloudwatch.tf
@@ -6,11 +6,10 @@ resource "aws_cloudwatch_metric_alarm" "rabbitmq_cluster_status" {
   metric_name               = "${var.env}-rabbitmq${count.index + 1}"
   namespace                 = "RabbitMQClusterStatus"
   period                    = "60"
-  statistic                 = "Average"
+  statistic                 = "Maximum"
   threshold                 = "1"
   alarm_description         = "${var.env} rabbit mq ${count.index + 1} reporting cluster paritions"
   alarm_actions             = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
-  insufficient_data_actions = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
   treat_missing_data        = "breaching"
 }
 
@@ -26,7 +25,6 @@ resource "aws_cloudwatch_metric_alarm" "rabbitmq_cpu" {
   threshold           = "80"
   alarm_description   = "Alert generated if over 80% CPU usage"
   alarm_actions       = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
-  treat_missing_data  = "breaching"
 
   dimensions {
     "InstanceId" = "${element(aws_instance.rabbitmq.*.id,count.index)}"
@@ -45,8 +43,6 @@ resource "aws_cloudwatch_metric_alarm" "rabbitmq_status" {
   threshold                 = "1"
   alarm_description         = "Alert generated if status changes to failure"
   alarm_actions             = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
-  insufficient_data_actions = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
-  treat_missing_data        = "breaching"
 
   dimensions {
     "InstanceId" = "${element(aws_instance.rabbitmq.*.id,count.index)}"

--- a/survey-runner-queue/cloudwatch.tf
+++ b/survey-runner-queue/cloudwatch.tf
@@ -1,28 +1,15 @@
-resource "aws_cloudwatch_metric_alarm" "rabbitmq1_cluster_status" {
-  alarm_name          = "${var.env}-rabbitmq1-cluster-alert"
-  evaluation_periods  = "1"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  metric_name         = "${var.env}-rabbitmq1"
-  namespace           = "RabbitMQClusterStatus"
-  period              = "60"
-  statistic           = "Average"
-  threshold           = "1"
-  alarm_description   = "${var.env} rabbit mq 1 reporting cluster paritions"
-  alarm_actions       = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
-  insufficient_data_actions = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
-}
-
-resource "aws_cloudwatch_metric_alarm" "rabbitmq2_cluster_status" {
-  alarm_name          = "${var.env}-rabbitmq2-cluster-alert"
-  evaluation_periods  = "1"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  metric_name         = "${var.env}-rabbitmq2"
-  namespace           = "RabbitMQClusterStatus"
-  period              = "60"
-  statistic           = "Average"
-  threshold           = "1"
-  alarm_description   = "${var.env} rabbit mq 2 reporting cluster paritions"
-  alarm_actions       = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
+resource "aws_cloudwatch_metric_alarm" "rabbitmq_cluster_status" {
+  count                     = 2
+  alarm_name                = "${var.env}-rabbitmq${count.index + 1}-cluster-alert"
+  evaluation_periods        = "1"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  metric_name               = "${var.env}-rabbitmq${count.index + 1}"
+  namespace                 = "RabbitMQClusterStatus"
+  period                    = "60"
+  statistic                 = "Average"
+  threshold                 = "1"
+  alarm_description         = "${var.env} rabbit mq ${count.index + 1} reporting cluster paritions"
+  alarm_actions             = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
   insufficient_data_actions = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
 }
 
@@ -45,17 +32,17 @@ resource "aws_cloudwatch_metric_alarm" "rabbitmq_cpu" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "rabbitmq_status" {
-  count               = 2
-  alarm_name          = "${var.env}-rabbitmq-${count.index + 1}-status-alert"
-  evaluation_periods  = "1"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  metric_name         = "StatusCheckFailed"
-  namespace           = "AWS/EC2"
-  period              = "60"
-  statistic           = "Maximum"
-  threshold           = "1"
-  alarm_description   = "Alert generated if status changes to failure"
-  alarm_actions       = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
+  count                     = 2
+  alarm_name                = "${var.env}-rabbitmq${count.index + 1}-status-alert"
+  evaluation_periods        = "1"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  metric_name               = "StatusCheckFailed"
+  namespace                 = "AWS/EC2"
+  period                    = "60"
+  statistic                 = "Maximum"
+  threshold                 = "1"
+  alarm_description         = "Alert generated if status changes to failure"
+  alarm_actions             = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
   insufficient_data_actions = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
 
   dimensions {

--- a/survey-runner-queue/cloudwatch.tf
+++ b/survey-runner-queue/cloudwatch.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_metric_alarm" "rabbitmq_cluster_status" {
   count                     = 2
   alarm_name                = "${var.env}-rabbitmq${count.index + 1}-cluster-alert"
-  evaluation_periods        = "1"
+  evaluation_periods        = "2"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   metric_name               = "${var.env}-rabbitmq${count.index + 1}"
   namespace                 = "RabbitMQClusterStatus"

--- a/survey-runner-queue/message_queue.tf
+++ b/survey-runner-queue/message_queue.tf
@@ -31,8 +31,9 @@ data "template_file" "hosts" {
   vars = {
     rabbitmq1_ip = "${aws_instance.rabbitmq.0.private_ip}"
     rabbitmq2_ip = "${aws_instance.rabbitmq.1.private_ip}"
+    rabbitmq1_fqdn = "${element(aws_route53_record.rabbitmq.*.fqdn, 1)}"
+    rabbitmq2_fqdn = "${element(aws_route53_record.rabbitmq.*.fqdn, 2)}"
     deploy_env   = "${var.env}"
-    deploy_dns   = "${data.aws_route53_zone.dns_zone.name}"
   }
 }
 
@@ -116,7 +117,7 @@ resource "null_resource" "ansible" {
   }
 
   provisioner "local-exec" {
-    command = "ansible-playbook -i '${var.env}-rabbitmq1.${data.aws_route53_zone.dns_zone.name},${var.env}-rabbitmq2.${data.aws_route53_zone.dns_zone.name}'  --private-key ${var.aws_key_pair}.pem tmp/eq-messaging/ansible/rabbitmq-cluster.yml --extra-vars '{\"deploy_env\":\"${var.env}\",\"deploy_dns\":\"${var.dns_zone_name}\",\"rabbitmq_admin_user\":\"${var.rabbitmq_admin_user}\",\"rabbitmq_admin_password\":\"${var.rabbitmq_admin_password}\",\"rabbitmq_write_user\":\"${var.rabbitmq_write_user}\",\"rabbitmq_write_password\":\"${var.rabbitmq_write_password}\",\"rabbitmq_read_user\":\"${var.rabbitmq_read_user}\",\"rabbitmq_read_password\":\"${var.rabbitmq_read_password}\", \"rsyslogd_server_IP\":\"${var.rsyslogd_server_ip}\", \"region\":\"${var.aws_default_region}\"}'"
+    command = "ansible-playbook -i '${element(aws_route53_record.rabbitmq.*.fqdn, 1)},${element(aws_route53_record.rabbitmq.*.fqdn, 2)}'  --private-key ${var.aws_key_pair}.pem tmp/eq-messaging/ansible/rabbitmq-cluster.yml --extra-vars '{\"deploy_env\":\"${var.env}\",\"deploy_dns\":\"${var.dns_zone_name}\",\"rabbitmq_admin_user\":\"${var.rabbitmq_admin_user}\",\"rabbitmq_admin_password\":\"${var.rabbitmq_admin_password}\",\"rabbitmq_write_user\":\"${var.rabbitmq_write_user}\",\"rabbitmq_write_password\":\"${var.rabbitmq_write_password}\",\"rabbitmq_read_user\":\"${var.rabbitmq_read_user}\",\"rabbitmq_read_password\":\"${var.rabbitmq_read_password}\", \"rsyslogd_server_IP\":\"${var.rsyslogd_server_ip}\", \"region\":\"${var.aws_default_region}\"}'"
   }
 
   provisioner "local-exec" {

--- a/survey-runner-queue/message_queue.tf
+++ b/survey-runner-queue/message_queue.tf
@@ -118,7 +118,7 @@ resource "null_resource" "ansible" {
   }
 
   provisioner "local-exec" {
-    command = "ansible-playbook -i '${element(aws_route53_record.rabbitmq.*.fqdn, 1)},${element(aws_route53_record.rabbitmq.*.fqdn, 2)}'  --private-key ${var.aws_key_pair}.pem tmp/eq-messaging/ansible/rabbitmq-cluster.yml --extra-vars '{\"deploy_env\":\"${var.env}\",\"deploy_dns\":\"${var.dns_zone_name}\",\"rabbitmq_admin_user\":\"${var.rabbitmq_admin_user}\",\"rabbitmq_admin_password\":\"${var.rabbitmq_admin_password}\",\"rabbitmq_write_user\":\"${var.rabbitmq_write_user}\",\"rabbitmq_write_password\":\"${var.rabbitmq_write_password}\",\"rabbitmq_read_user\":\"${var.rabbitmq_read_user}\",\"rabbitmq_read_password\":\"${var.rabbitmq_read_password}\", \"rsyslogd_server_IP\":\"${var.rsyslogd_server_ip}\", \"region\":\"${var.aws_default_region}\"}'"
+    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i '${element(aws_route53_record.rabbitmq.*.fqdn, 1)},${element(aws_route53_record.rabbitmq.*.fqdn, 2)}'  --private-key ${var.aws_key_pair}.pem tmp/eq-messaging/ansible/rabbitmq-cluster.yml --extra-vars '{\"deploy_env\":\"${var.env}\",\"deploy_dns\":\"${var.dns_zone_name}\",\"rabbitmq_admin_user\":\"${var.rabbitmq_admin_user}\",\"rabbitmq_admin_password\":\"${var.rabbitmq_admin_password}\",\"rabbitmq_write_user\":\"${var.rabbitmq_write_user}\",\"rabbitmq_write_password\":\"${var.rabbitmq_write_password}\",\"rabbitmq_read_user\":\"${var.rabbitmq_read_user}\",\"rabbitmq_read_password\":\"${var.rabbitmq_read_password}\", \"rsyslogd_server_IP\":\"${var.rsyslogd_server_ip}\", \"region\":\"${var.aws_default_region}\"}'"
   }
 
   provisioner "local-exec" {

--- a/survey-runner-queue/message_queue.tf
+++ b/survey-runner-queue/message_queue.tf
@@ -7,6 +7,7 @@ resource "aws_instance" "rabbitmq" {
   subnet_id                   = "${aws_subnet.queue.id}"
   private_ip                  = "${var.rabbitmq_ips[count.index]}"
   associate_public_ip_address = true
+  monitoring                  = true
 
   vpc_security_group_ids = ["${aws_security_group.rabbit_required.id}",
     "${aws_security_group.provision-allow-ssh-REMOVE.id}",
@@ -15,12 +16,12 @@ resource "aws_instance" "rabbitmq" {
   ]
 
   root_block_device {
-    volume_type = "gp2"
+    volume_type           = "gp2"
     delete_on_termination = "${var.delete_volume_on_termination}"
   }
 
   tags {
-    Name = "${var.env}-rabbitmq-${count.index + 1}"
+    Name    = "${var.env}-rabbitmq-${count.index + 1}"
     Service = "${var.env}-RabbitMQ"
   }
 }
@@ -29,11 +30,11 @@ data "template_file" "hosts" {
   template = "${file("${path.module}/templates/hosts")}"
 
   vars = {
-    rabbitmq1_ip = "${aws_instance.rabbitmq.0.private_ip}"
-    rabbitmq2_ip = "${aws_instance.rabbitmq.1.private_ip}"
+    rabbitmq1_ip   = "${aws_instance.rabbitmq.0.private_ip}"
+    rabbitmq2_ip   = "${aws_instance.rabbitmq.1.private_ip}"
     rabbitmq1_fqdn = "${element(aws_route53_record.rabbitmq.*.fqdn, 1)}"
     rabbitmq2_fqdn = "${element(aws_route53_record.rabbitmq.*.fqdn, 2)}"
-    deploy_env   = "${var.env}"
+    deploy_env     = "${var.env}"
   }
 }
 

--- a/survey-runner-queue/security_groups.tf
+++ b/survey-runner-queue/security_groups.tf
@@ -115,4 +115,11 @@ resource "aws_security_group" "survey_runner_vpn_sdx_access" {
     protocol    = "tcp"
     cidr_blocks = "${var.sdx_cidrs}"
   }
+  # RabbitMQ API - Used for Monitoring
+  ingress {
+    from_port   = 15672
+    to_port     = 15672
+    protocol    = "tcp"
+    cidr_blocks = "${var.sdx_cidrs}"
+  }
 }

--- a/survey-runner-queue/templates/hosts
+++ b/survey-runner-queue/templates/hosts
@@ -1,6 +1,6 @@
 127.0.0.1 localhost
-${rabbitmq1_ip} ${deploy_env}-rabbitmq1.${deploy_dns} ${deploy_env}-rabbitmq1
-${rabbitmq2_ip} ${deploy_env}-rabbitmq2.${deploy_dns} ${deploy_env}-rabbitmq2
+${rabbitmq1_ip} ${rabbitmq1_fqdn} ${deploy_env}-rabbitmq1
+${rabbitmq2_ip} ${rabbitmq2_fqdn} ${deploy_env}-rabbitmq2
 
 
 # The following lines are desirable for IPv6 capable hosts


### PR DESCRIPTION
### What is the context of this PR?
The Ansible scripts were failing silently when the hostnames in the `ansible-playbook` command had a trailing dot.
This was very susceptible to user error.
The new solution is not susceptible and uses the FQDN from the DNS record.

Also Fixes https://github.com/ONSdigital/eq-terraform/issues/88

### How to review
Deploy the infrastructure on AWS.
Run through a survey and submit.
The survey should be submitted successfully.