### PR TITLE
Restrict ECS to ONS IPs

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,1 +1,0 @@
-survey-runner-queue/ansible.cfg

--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -97,6 +97,11 @@ variable "ecs_cluster_max_size" {
   default     = "3"
 }
 
+variable "auto_deploy_updated_tags" {
+  description = "Should updated tags of images be automatically deployed"
+  default     = true
+}
+
 // Survey Runner on Elastic Beanstalk
 variable "eb_instance_type" {
   description = "Elastic Beanstalk Instance Type"

--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -40,18 +40,20 @@ module "survey-runner-on-beanstalk" {
 }
 
 module "eq-ecs" {
-  source                  = "github.com/ONSdigital/eq-terraform-ecs"
-  env                     = "${var.env}"
-  aws_access_key          = "${var.aws_access_key}"
-  aws_secret_key          = "${var.aws_secret_key}"
-  ecs_instance_type       = "${var.ecs_instance_type}"
-  certificate_arn         = "${var.certificate_arn}"
-  vpc_id                  = "${module.survey-runner-vpc.vpc_id}"
-  public_subnet_ids       = "${module.survey-runner-routing.public_subnet_ids}"
-  ecs_application_cidrs   = "${var.ecs_application_cidrs}"
-  private_route_table_ids = "${module.survey-runner-routing.private_route_table_ids}"
-  ecs_cluster_min_size    = "${var.ecs_cluster_min_size}"
-  ecs_cluster_max_size    = "${var.ecs_cluster_max_size}"
+  source                   = "github.com/ONSdigital/eq-terraform-ecs"
+  env                      = "${var.env}"
+  aws_access_key           = "${var.aws_access_key}"
+  aws_secret_key           = "${var.aws_secret_key}"
+  ecs_instance_type        = "${var.ecs_instance_type}"
+  certificate_arn          = "${var.certificate_arn}"
+  vpc_id                   = "${module.survey-runner-vpc.vpc_id}"
+  public_subnet_ids        = "${module.survey-runner-routing.public_subnet_ids}"
+  ecs_application_cidrs    = "${var.ecs_application_cidrs}"
+  private_route_table_ids  = "${module.survey-runner-routing.private_route_table_ids}"
+  ecs_cluster_min_size     = "${var.ecs_cluster_min_size}"
+  ecs_cluster_max_size     = "${var.ecs_cluster_max_size}"
+  auto_deploy_updated_tags = "${var.auto_deploy_updated_tags}"
+  ons_access_ips           = ["${split(",", var.ons_access_ips)}"]
 }
 
 module "survey-runner-on-ecs" {


### PR DESCRIPTION
### What is the context of this PR?
Restrict the ECS cluster and ALB to only be accessible via ONS IPs

### How to review
Deploy it to AWS and check it can't be accessed from outside of the network
