### PR TITLE
added preprod env variable for respondent accounts url

### DIFF
--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -162,6 +162,11 @@ variable "survey_runner_min_tasks" {
   default     = "1"
 }
 
+variable "respondent_account_url" {
+  description = "The url for the respondent log in"
+  default     = "https://survey.ons.gov.uk/"
+}
+
 // RabbitMQ
 variable "rabbitmq_instance_type" {
   description = "Rabbit MQ Instance type"

--- a/survey-runner-application/global_vars.tf
+++ b/survey-runner-application/global_vars.tf
@@ -125,6 +125,11 @@ variable "secrets_file_name" {
   default     = "secrets.yml"
 }
 
+variable "respondent_account_url" {
+  description = "The url for the respondent log in"
+  default     = "https://survey.ons.gov.uk/"
+}
+
 # Database
 variable "database_address" {
   description = "The address of the postgres database"

--- a/survey-runner-application/survey_runner.tf
+++ b/survey-runner-application/survey_runner.tf
@@ -223,6 +223,11 @@ resource "aws_elastic_beanstalk_environment" "survey_runner_prime" {
     value     = "${var.google_analytics_code}"
   }
   setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "RESPONDENT_ACCOUNT_URL"
+    value     = "${var.respondent_account_url}"
+  }
+  setting {
     namespace = "aws:elasticbeanstalk:container:python"
     name      = "NumProcesses"
     value     = "${var.wsgi_number_of_processes}"

--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -38,6 +38,7 @@ module "survey-runner-on-beanstalk" {
   deployment_policy       = "${var.eb_deployment_policy}"
   rolling_update_enabled  = "${var.eb_rolling_update_enabled}"
   secrets_file_name       = "${var.survey_runner_secrets_file_name}"
+  respondent_account_url  = "${var.respondent_account_url}"
 }
 
 module "eq-ecs" {
@@ -75,6 +76,7 @@ module "survey-runner-on-ecs" {
   docker_registry         = "${var.survey_runner_docker_registry}"
   survey_runner_tag       = "${var.survey_runner_tag}"
   secrets_file_name       = "${var.survey_runner_secrets_file_name}"
+  respondent_account_url  = "${var.respondent_account_url}"
 }
 
 module "survey-launcher-for-elastic-beanstalk" {


### PR DESCRIPTION
### What is the context of this PR?
In relation to : 
https://trello.com/c/7VACxFOq/1016-clear-actions-to-exit-or-continue-a-survey-s
See: https://github.com/ONSdigital/eq-survey-runner/pull/1274
Having to add a variable for preprod for the respondent accounts url for when terraform is ran and deployed.

### How to review
Get Jon to review