### PR TITLE
Use the new service name on eq-ecs-deploy

### DIFF
--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -94,7 +94,7 @@ variable "ecs_cluster_min_size" {
 
 variable "auto_deploy_updated_tags" {
   description = "Should updated tags of images be automatically deployed"
-  default     = true
+  default     = "true"
 }
 
 // Survey Runner on Elastic Beanstalk

--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -87,6 +87,7 @@ module "survey-launcher-for-elastic-beanstalk" {
   dns_zone_name          = "${var.dns_zone_name}"
   ecs_cluster_name       = "${module.eq-ecs.ecs_cluster_name}"
   aws_alb_listener_arn   = "${module.eq-ecs.aws_alb_listener_arn}"
+  service_name           = "surveys-launch"
   listener_rule_priority = 100
   docker_registry        = "${var.survey_launcher_registry}"
   container_name         = "go-launch-a-survey"
@@ -121,6 +122,7 @@ module "survey-launcher-for-ecs" {
   dns_zone_name          = "${var.dns_zone_name}"
   ecs_cluster_name       = "${module.eq-ecs.ecs_cluster_name}"
   aws_alb_listener_arn   = "${module.eq-ecs.aws_alb_listener_arn}"
+  service_name           = "surveys-launch"
   listener_rule_priority = 101
   docker_registry        = "${var.survey_launcher_registry}"
   container_name         = "go-launch-a-survey"


### PR DESCRIPTION
### What is the context of this PR?
This makes the URL for the launcher consistent with what it was before

### How to review
After applying the terraform your launcher should be available at `https://ENV-surveys-launch.dev.eq.ons.digital/`