### PR TITLE
Added author registry override to developer defaults

### DIFF
--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -287,6 +287,11 @@ variable "survey_launcher_jwt_signing_key_path" {
 
 
 // Author
+variable "author_registry" {
+  description = "The docker repository for the author images to run"
+  default     = "onsdigital"
+}
+
 variable "author_tag" {
   description = "The tag for the Author image to run"
   default     = "latest"

--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -159,6 +159,7 @@ module "author" {
   ecs_cluster_name        = "${module.eq-ecs.ecs_cluster_name}"
   aws_alb_listener_arn    = "${module.eq-ecs.aws_alb_listener_arn}"
   application_cidrs       = "${concat(var.ecs_application_cidrs, var.application_cidrs)}"
+  docker_registry         = "${var.author_registry}"
   author_tag              = "${var.author_tag}"
   author_api_tag          = "${var.author_api_tag}"
   publisher_tag           = "${var.publisher_tag}"


### PR DESCRIPTION
### What is the context of this PR?
This PR allows the author docker registry to be overridden.
This allows us to pull from ECR when deploying to staging/pre-prod etc

### How to review
Run `terraform apply` and check that author is deployed as expected for a developer.