### PR TITLE
Pass the NAT gateway IPs into the ECS module

### DIFF
--- a/survey-runner-routing/outputs.tf
+++ b/survey-runner-routing/outputs.tf
@@ -5,3 +5,7 @@ output "private_route_table_ids" {
 output "public_subnet_ids" {
   value = ["${aws_subnet.public.*.id}"]
 }
+
+output "nat_gateway_ips" {
+  value = "${aws_eip.nat_eip.*.public_ip}"
+}

--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -42,7 +42,7 @@ module "survey-runner-on-beanstalk" {
 }
 
 module "eq-ecs" {
-  source                   = "github.com/ONSdigital/eq-terraform-ecs"
+  source                   = "github.com/ONSdigital/eq-terraform-ecs?ref=allow-alb-access-from-ecs"
   env                      = "${var.env}"
   aws_access_key           = "${var.aws_access_key}"
   aws_secret_key           = "${var.aws_secret_key}"
@@ -55,6 +55,7 @@ module "eq-ecs" {
   ecs_cluster_min_size     = "${var.ecs_cluster_min_size}"
   auto_deploy_updated_tags = "${var.auto_deploy_updated_tags}"
   ons_access_ips           = ["${split(",", var.ons_access_ips)}"]
+  eq_gateway_ips           = ["${module.survey-runner-routing.nat_gateway_ips}"]
 }
 
 module "survey-runner-on-ecs" {


### PR DESCRIPTION
### What is the context of this PR?
The ALB requires the IPs for the NAT gateway to that it can allow access from publisher to author-api

### How to review
Run this and try to preview a survey

This PR also tests https://github.com/ONSdigital/eq-terraform-ecs/pull/12