### PR TITLE
Added VPC endpoints for DynamoDB and S3

### DIFF
--- a/survey-runner-routing/aws.tf
+++ b/survey-runner-routing/aws.tf
@@ -3,3 +3,7 @@ provider "aws" {
   secret_key = "${var.aws_secret_key}"
   region     = "eu-west-1"
 }
+
+data "aws_region" "current" {
+  current = true
+}

--- a/survey-runner-routing/vpc_endpoint.tf
+++ b/survey-runner-routing/vpc_endpoint.tf
@@ -1,0 +1,11 @@
+resource "aws_vpc_endpoint" "private_dynamodb" {
+  vpc_id       = "${var.vpc_id}"
+  service_name = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
+  route_table_ids = ["${aws_route_table.private.*.id}"]
+}
+
+resource "aws_vpc_endpoint" "private_s3" {
+  vpc_id       = "${var.vpc_id}"
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  route_table_ids = ["${aws_route_table.private.*.id}"]
+}


### PR DESCRIPTION
### What is the context of this PR?
Added VPC endpoints for DynamoDB and S3 so that traffic between our private subnets and these services never goes across the public internet

### How to review
Can we communicate with DynamoDB and S3 from the application