### PR TITLE
Refactor author components into eq-ecs-deploy module instances

### DIFF
--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -380,7 +380,31 @@ variable "author_api_min_tasks" {
 
 variable "publisher_min_tasks" {
   description = "The minimum number of Publisher tasks to run"
-  default     = "1"
+  default = "1"
+}
+
+variable "author_use_sentry" {
+  description   = "Use sentry for bug reporting."
+  default       = "true"
+}
+variable "author_use_fullstory" {
+  description   = "Use fullstory for capturing user sessions."
+  default       = "true"
+}
+
+variable "author_database_name" {
+  description = "The name of the author database"
+  default     = "author"
+}
+
+variable "author_database_user" {
+  description = "The name of the author database user"
+  default     = "author"
+}
+
+variable "author_database_password" {
+  description = "The password of the author database user"
+  default     = "digitaleq"
 }
 
 // Schema Validator

--- a/survey-runner-database/cloudwatch.tf
+++ b/survey-runner-database/cloudwatch.tf
@@ -7,7 +7,6 @@ resource "aws_cloudwatch_metric_alarm" "database_storage_alert" {
   period              = "300"
   statistic           = "Minimum"
   threshold           = "${var.database_free_storage_alert_level * 1024 * 1024 * 1024}"
-  evaluation_periods  = "1"
   alarm_description   = "Alert generated if the DB has less than a ${var.database_free_storage_alert_level}GB of spage left"
   alarm_actions       = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
 
@@ -25,7 +24,6 @@ resource "aws_cloudwatch_metric_alarm" "database_cpu_alert" {
   period              = "300"
   statistic           = "Average"
   threshold           = "80"
-  evaluation_periods  = "1"
   alarm_description   = "Alert generated if the DB is using more than 80% CPU"
   alarm_actions       = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
 
@@ -43,7 +41,6 @@ resource "aws_cloudwatch_metric_alarm" "database_free_memory_alert" {
   period              = "300"
   statistic           = "Average"
   threshold           = "${var.database_free_memory_alert_level * 1024 * 1024}"
-  evaluation_periods  = "1"
   alarm_description   = "Alert generated if the DB has less than a ${var.database_free_memory_alert_level}MB of memory left"
   alarm_actions       = ["arn:aws:sns:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.env}-slack-alert"]
 

--- a/survey-runner-database/database.tf
+++ b/survey-runner-database/database.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "survey_runner_rds_access" {
-  name        = "${var.env}-rds-access"
+  name        = "${var.rds_security_group_name}"
   description = "Database access from the application subnet"
   vpc_id      = "${var.vpc_id}"
 
@@ -15,19 +15,9 @@ resource "aws_security_group" "survey_runner_rds_access" {
   }
 }
 
-resource "aws_db_subnet_group" "survey_runner_rds" {
-  name        = "${var.env}-eq-rds"
-  description = "Database subnet group"
-  subnet_ids  = ["${aws_subnet.database.*.id}"]
-
-  tags {
-    Name = "${var.env}-db-subnet-group"
-  }
-}
-
 resource "aws_db_instance" "survey_runner_database" {
   allocated_storage           = "${var.database_allocated_storage}"
-  identifier                  = "${var.env}-digitaleqrds"
+  identifier                  = "${var.database_identifier}"
   engine                      = "postgres"
   engine_version              = "${var.database_engine_version}"
   allow_major_version_upgrade = "${var.allow_major_version_upgrade}"
@@ -38,7 +28,7 @@ resource "aws_db_instance" "survey_runner_database" {
   multi_az                    = "${var.multi_az}"
   publicly_accessible         = false
   backup_retention_period     = "${var.backup_retention_period}"
-  db_subnet_group_name        = "${aws_db_subnet_group.survey_runner_rds.name}"
+  db_subnet_group_name        = "${var.db_subnet_group_name}"
   vpc_security_group_ids      = ["${aws_security_group.survey_runner_rds_access.id}"]
   storage_type                = "gp2"
   apply_immediately           = "${var.database_apply_immediately}"

--- a/survey-runner-database/global_vars.tf
+++ b/survey-runner-database/global_vars.tf
@@ -10,12 +10,6 @@ variable "aws_access_key" {
   description = "Amazon Web Service Access Key"
 }
 
-variable "availability_zones" {
-  type        = "list"
-  description = "The availability zones"
-  default     = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-}
-
 variable "vpc_id" {
   description = "The survey runner VPC ID"
 }
@@ -28,11 +22,6 @@ variable "private_route_table_ids" {
 variable "application_cidrs" {
   type        = "list"
   description = "CIDR blocks for application subnets"
-}
-
-variable "database_cidrs" {
-  type        = "list"
-  description = "CIDR blocks for database subnets"
 }
 
 variable "database_allocated_storage" {
@@ -96,6 +85,18 @@ variable "snapshot_identifier" {
   default     = ""
 }
 
-variable "preferred_maintenance_window"{
+variable "preferred_maintenance_window" {
   default   = "Tue:02:00-Tue:02:30"
+}
+
+variable "db_subnet_group_name" {
+  description = "The name of the database subnet group."
+}
+
+variable "database_identifier" {
+  description = "An unique identifier for the database."
+}
+
+variable "rds_security_group_name" {
+  description = "The name of the security group for the rds database."
 }

--- a/survey-runner-routing/global_vars.tf
+++ b/survey-runner-routing/global_vars.tf
@@ -23,6 +23,11 @@ variable "public_cidrs" {
   description = "CIDR blocks for public subnets"
 }
 
+variable "database_cidrs" {
+  type        = "list"
+  description = "CIDR blocks for database subnets"
+}
+
 variable "vpc_peer_connection_id" {
   description = "The conneciton id of the peered VPC, optional"
   default     = ""
@@ -37,4 +42,9 @@ variable "availability_zones" {
   type        = "list"
   description = "The availability zones"
   default     = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+}
+
+variable "database_subnet_ids" {
+  type        = "list"
+  description = "Ids of the database subnets"
 }

--- a/survey-runner-routing/routing.tf
+++ b/survey-runner-routing/routing.tf
@@ -33,3 +33,10 @@ resource "aws_route" "public_internet_gateway" {
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${var.internet_gateway_id}"
 }
+
+# Associate subnets with route table to NAT gateway
+resource "aws_route_table_association" "private" {
+  count          = "${length(var.database_cidrs)}"
+  subnet_id      = "${element(var.database_subnet_ids, count.index)}"
+  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
+}

--- a/survey-runner-vpc/global_vars.tf
+++ b/survey-runner-vpc/global_vars.tf
@@ -13,3 +13,14 @@ variable "aws_access_key" {
 variable "vpc_cidr_block" {
   description = "VPC CIDR block"
 }
+
+variable "database_cidrs" {
+  type        = "list"
+  description = "CIDR blocks for database subnets"
+}
+
+variable "availability_zones" {
+  type        = "list"
+  description = "The availability zones"
+  default     = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+}

--- a/survey-runner-vpc/outputs.tf
+++ b/survey-runner-vpc/outputs.tf
@@ -5,3 +5,12 @@ output "vpc_id" {
 output "internet_gateway_id" {
   value = "${aws_internet_gateway.igw.id}"
 }
+
+output "database_subnet_ids" {
+  value = ["${aws_subnet.database.*.id}"]
+}
+
+
+output "database_subnet_group_name" {
+  value = "${aws_db_subnet_group.eq_rds.name}"
+}

--- a/survey-runner-vpc/subnets.tf
+++ b/survey-runner-vpc/subnets.tf
@@ -1,7 +1,7 @@
 # Private database subnets
 resource "aws_subnet" "database" {
   count             = "${length(var.database_cidrs)}"
-  vpc_id            = "${var.vpc_id}"
+  vpc_id            = "${aws_vpc.survey_runner.id}"
   cidr_block        = "${var.database_cidrs[count.index]}"
   availability_zone = "${var.availability_zones[count.index]}"
 
@@ -12,9 +12,12 @@ resource "aws_subnet" "database" {
   }
 }
 
-# Associate subnets with route table to NAT gateway
-resource "aws_route_table_association" "private" {
-  count          = "${length(var.database_cidrs)}"
-  subnet_id      = "${element(aws_subnet.database.*.id, count.index)}"
-  route_table_id = "${var.private_route_table_ids[count.index]}"
+resource "aws_db_subnet_group" "eq_rds" {
+  name        = "${var.env}-eq-rds"
+  description = "Database subnet group"
+  subnet_ids  = ["${aws_subnet.database.*.id}"]
+
+  tags {
+    Name = "${var.env}-db-subnet-group"
+  }
 }


### PR DESCRIPTION
### Description

This PR makes various changes to the eq-terraform configuration in order for author, author-api and publisher applications to be specified in terms of eq-ecs-deploy module instances.

Specifically:

 - Database module has been generalised, moving route and subnet creation configuration to more appropriate modules.
 - Add new module instances for author, author-api and publisher.
 - Update environment variables for containers with appropriate values.
 - Override health check values for author ([see related pull request on eq-ecs-deploy](https://github.com/ONSdigital/eq-ecs-deploy/pull/10)).
 - Resolved merge conflicts with recent changes to set the minimum number of tasks on author, author-api and publisher.

### Dependencies
 - https://github.com/ONSdigital/eq-ecs-deploy/pull/10
 - https://github.com/ONSdigital/eq-deploy/pull/22

### How to review
Changes should look sensible.
Should be possible to spin up an environment by runnning the scripts.
