### PR TITLE
Migrate Runner to use ECS deploy

### DIFF
--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -177,6 +177,32 @@ variable "respondent_account_url" {
   default     = "https://survey.ons.gov.uk/"
 }
 
+variable "survey_runner_message_queue_name" {
+  description = "RabbitMQ submission queue name"
+  default     = "submit_q"
+}
+
+variable "survey_runner_log_level" {
+  description = "The Survey Runner logging level (One of ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'])"
+  default     = "INFO"
+}
+
+  # Survey Runner New Relic
+variable "survey_runner_new_relic_enabled" {
+  description = "Enable NewRelic monitoring"
+  default     = "False"
+}
+
+variable "survey_runner_new_relic_app_name" {
+  description = "NewRelic App Name"
+  default     = "Survey Runner"
+}
+
+variable "survey_runner_new_relic_licence_key" {
+  description = "NewRelic Licence Key"
+  default     = ""
+}
+
 // RabbitMQ
 variable "rabbitmq_instance_type" {
   description = "Rabbit MQ Instance type"
@@ -280,6 +306,11 @@ variable "survey_launcher_tag" {
   default     = "latest"
 }
 
+variable "survey_launcher_min_tasks" {
+  description = "The minimum number of Survey Launcher tasks to run"
+  default     = "1"
+}
+
 variable "survey_launcher_s3_secrets_bucket" {
   description = "The S3 bucket that contains the secrets"
   default     = ""
@@ -295,25 +326,6 @@ variable "survey_launcher_jwt_signing_key_path" {
   default     = "jwt-test-keys/sdc-user-authentication-signing-rrm-private-key.pem"
 }
 
-variable "survey_launcher_for_elastic_beanstalk_min_tasks" {
-  description = "The minimum number of Survey Launcher tasks to run"
-  default     = "1"
-}
-
-variable "survey_launcher_for_ecs_min_tasks" {
-  description = "The minimum number of Survey Launcher tasks to run"
-  default     = "1"
-}
-
-variable "schema_validator_min_tasks" {
-  description = "The minimum number of Schema Validator tasks to run"
-  default     = "1"
-}
-
-variable "survey_register_min_tasks" {
-  description = "The minimum number of Survey Register tasks to run"
-  default     = "1"
-}
 
 // Author
 variable "author_registry" {
@@ -382,6 +394,11 @@ variable "schema_validator_tag" {
   default     = "latest"
 }
 
+variable "schema_validator_min_tasks" {
+  description = "The minimum number of Schema Validator tasks to run"
+  default     = "1"
+}
+
 // Survey Register
 variable "survey_register_registry" {
   description = "The docker repository for the Survey Register image to run"
@@ -391,4 +408,9 @@ variable "survey_register_registry" {
 variable "survey_register_tag" {
   description = "The tag for the Survey Register image to run"
   default     = "latest"
+}
+
+variable "survey_register_min_tasks" {
+  description = "The minimum number of Survey Register tasks to run"
+  default     = "1"
 }

--- a/survey-runner-routing/aws.tf
+++ b/survey-runner-routing/aws.tf
@@ -5,5 +5,4 @@ provider "aws" {
 }
 
 data "aws_region" "current" {
-  current = true
 }

--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -62,35 +62,142 @@ module "eq-ecs" {
 }
 
 module "survey-runner-on-ecs" {
-  source                         = "github.com/ONSdigital/eq-survey-runner-deploy"
-  env                            = "${var.env}-new"
-  aws_access_key                 = "${var.aws_access_key}"
-  aws_secret_key                 = "${var.aws_secret_key}"
-  vpc_id                         = "${module.survey-runner-vpc.vpc_id}"
-  dns_zone_name                  = "${var.dns_zone_name}"
-  ecs_cluster_name               = "${module.eq-ecs.ecs_cluster_name}"
-  aws_alb_arn                    = "${module.eq-ecs.aws_alb_arn}"
-  aws_alb_listener_arn           = "${module.eq-ecs.aws_alb_listener_arn}"
-  s3_secrets_bucket              = "${var.survey_runner_s3_secrets_bucket}"
-  database_host                  = "${module.survey-runner-database.database_address}"
-  database_port                  = "${module.survey-runner-database.database_port}"
-  database_name                  = "${var.database_name}"
-  rabbitmq_ip_prime              = "${module.survey-runner-queue.rabbitmq_ip_prime}"
-  rabbitmq_ip_failover           = "${module.survey-runner-queue.rabbitmq_ip_failover}"
-  google_analytics_code          = "${var.google_analytics_code}"
-  survey_runner_min_tasks        = "${var.survey_runner_min_tasks}"
-  survey_runner_static_min_tasks = "${var.survey_runner_static_min_tasks}"
-  docker_registry                = "${var.survey_runner_docker_registry}"
-  survey_runner_tag              = "${var.survey_runner_tag}"
-  secrets_file_name              = "${var.survey_runner_secrets_file_name}"
-  keys_file_name                 = "${var.survey_runner_keys_file_name}"
-  respondent_account_url         = "${var.respondent_account_url}"
-  submitted_responses_table_name = "${module.survey-runner-dynamodb.submitted_responses_table_name}"
-  slack_alert_sns_arn            = "${module.survey-runner-alerting.slack_alert_sns_arn}"
+  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.4.0"
+  env                    = "${var.env}-new"
+  aws_access_key         = "${var.aws_access_key}"
+  aws_secret_key         = "${var.aws_secret_key}"
+  vpc_id                 = "${module.survey-runner-vpc.vpc_id}"
+  dns_zone_name          = "${var.dns_zone_name}"
+  ecs_cluster_name       = "${module.eq-ecs.ecs_cluster_name}"
+  aws_alb_arn            = "${module.eq-ecs.aws_alb_arn}"
+  service_name           = "surveys"
+  listener_rule_priority = 10
+  docker_registry        = "${var.survey_runner_docker_registry}"
+  container_name         = "eq-survey-runner"
+  container_port         = 5000
+  healthcheck_path       = "/status"
+  container_tag          = "${var.survey_runner_tag}"
+  application_min_tasks  = "${var.survey_runner_min_tasks}"
+  slack_alert_sns_arn    = "${module.survey-runner-alerting.slack_alert_sns_arn}"
+
+  container_environment_variables = <<EOF
+      {
+        "name": "EQ_RABBITMQ_HOST",
+        "value": "${module.survey-runner-queue.rabbitmq_ip_prime}"
+      },
+      {
+        "name": "EQ_RABBITMQ_HOST_SECONDARY",
+        "value": "${module.survey-runner-queue.rabbitmq_ip_failover}"
+      },
+      {
+        "name": "EQ_RABBITMQ_QUEUE_NAME",
+        "value": "${var.survey_runner_message_queue_name}"
+      },
+      {
+        "name": "EQ_SERVER_SIDE_STORAGE_DATABASE_HOST",
+        "value": "${module.survey-runner-database.database_address}"
+      },
+      {
+        "name": "EQ_SERVER_SIDE_STORAGE_DATABASE_PORT",
+        "value": "${module.survey-runner-database.database_port}"
+      },
+      {
+        "name": "EQ_SERVER_SIDE_STORAGE_DATABASE_NAME",
+        "value": "${var.database_name}"
+      },
+      {
+        "name": "EQ_LOG_LEVEL",
+        "value": "${var.survey_runner_log_level}"
+      },
+      {
+        "name": "EQ_UA_ID",
+        "value": "${var.google_analytics_code}"
+      },
+      {
+        "name": "SECRETS_S3_BUCKET",
+        "value": "${var.survey_runner_s3_secrets_bucket}"
+      },
+      {
+        "name": "EQ_SECRETS_FILE",
+        "value": "${var.survey_runner_secrets_file_name}"
+      },
+      {
+        "name": "EQ_KEYS_FILE",
+        "value": "${var.survey_runner_keys_file_name}"
+      },
+      {
+        "name": "RESPONDENT_ACCOUNT_URL",
+        "value": "${var.respondent_account_url}"
+      },
+      {
+        "name": "EQ_SUBMITTED_RESPONSES_TABLE_NAME",
+        "value": "${module.survey-runner-dynamodb.submitted_responses_table_name}"
+      },
+      {
+        "name": "EQ_NEW_RELIC_ENABLED",
+        "value": "${var.survey_runner_new_relic_enabled}"
+      },
+      {
+        "name": "NEW_RELIC_APP_NAME",
+        "value": "${var.survey_runner_new_relic_app_name}"
+      },
+      {
+        "name": "NEW_RELIC_LICENSE_KEY",
+        "value": "${var.survey_runner_new_relic_licence_key}"
+      }
+  EOF
+
+  task_has_iam_policy = true
+  task_iam_policy_json = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Sid": "",
+          "Effect": "Allow",
+          "Action": [
+              "s3:ListObjects",
+              "s3:ListBucket",
+              "s3:GetObject"
+          ],
+          "Resource": "arn:aws:s3:::*"
+      },
+      {
+          "Sid": "",
+          "Effect": "Allow",
+          "Action": [
+              "dynamodb:PutItem",
+              "dynamodb:GetItem"
+          ],
+          "Resource": "${module.survey-runner-dynamodb.submitted_responses_table_arn}"
+      }
+  ]
+}
+  EOF
+}
+module "survey-runner-static-on-ecs" {
+  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.4.0"
+  env                    = "${var.env}-new"
+  aws_access_key         = "${var.aws_access_key}"
+  aws_secret_key         = "${var.aws_secret_key}"
+  vpc_id                 = "${module.survey-runner-vpc.vpc_id}"
+  dns_zone_name          = "${var.dns_zone_name}"
+  dns_record_name        = "${var.env}-new-surveys.${var.dns_zone_name}"
+  ecs_cluster_name       = "${module.eq-ecs.ecs_cluster_name}"
+  aws_alb_arn            = "${module.eq-ecs.aws_alb_arn}"
+  service_name           = "surveys-static"
+  listener_rule_priority = 5
+  docker_registry        = "${var.survey_runner_docker_registry}"
+  container_name         = "eq-survey-runner-static"
+  container_port         = 80
+  container_tag          = "${var.survey_runner_tag}"
+  application_min_tasks  = "${var.survey_runner_min_tasks}"
+  slack_alert_sns_arn    = "${module.survey-runner-alerting.slack_alert_sns_arn}"
+  alb_listener_path_pattern = "/s/*"
 }
 
 module "survey-launcher-for-elastic-beanstalk" {
-  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.2.0"
+  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.4.0"
   env                    = "${var.env}"
   aws_access_key         = "${var.aws_access_key}"
   aws_secret_key         = "${var.aws_secret_key}"
@@ -104,7 +211,8 @@ module "survey-launcher-for-elastic-beanstalk" {
   container_name         = "go-launch-a-survey"
   container_port         = 8000
   container_tag          = "${var.survey_launcher_tag}"
-  application_min_tasks  = "${var.survey_launcher_for_elastic_beanstalk_min_tasks}"
+  application_min_tasks  = "${var.survey_launcher_min_tasks}"
+  slack_alert_sns_arn    = "${module.survey-runner-alerting.slack_alert_sns_arn}"
 
   container_environment_variables = <<EOF
       {
@@ -127,7 +235,7 @@ module "survey-launcher-for-elastic-beanstalk" {
 }
 
 module "survey-launcher-for-ecs" {
-  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.2.0"
+  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.4.0"
   env                    = "${var.env}-new"
   aws_access_key         = "${var.aws_access_key}"
   aws_secret_key         = "${var.aws_secret_key}"
@@ -136,12 +244,13 @@ module "survey-launcher-for-ecs" {
   ecs_cluster_name       = "${module.eq-ecs.ecs_cluster_name}"
   aws_alb_arn            = "${module.eq-ecs.aws_alb_arn}"
   service_name           = "surveys-launch"
-  listener_rule_priority = 101
+  listener_rule_priority = 15
   docker_registry        = "${var.survey_launcher_registry}"
   container_name         = "go-launch-a-survey"
   container_port         = 8000
   container_tag          = "${var.survey_launcher_tag}"
-  application_min_tasks  = "${var.survey_launcher_for_ecs_min_tasks}"
+  application_min_tasks  = "${var.survey_launcher_min_tasks}"
+  slack_alert_sns_arn    = "${module.survey-runner-alerting.slack_alert_sns_arn}"
 
   container_environment_variables = <<EOF
       {
@@ -189,7 +298,7 @@ module "author" {
 }
 
 module "schema-validator" {
-  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.2.0"
+  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.4.0"
   env                    = "${var.env}"
   aws_access_key         = "${var.aws_access_key}"
   aws_secret_key         = "${var.aws_secret_key}"
@@ -205,10 +314,11 @@ module "schema-validator" {
   container_tag          = "${var.schema_validator_tag}"
   healthcheck_path       = "/status"
   application_min_tasks  = "${var.schema_validator_min_tasks}"
+  slack_alert_sns_arn    = "${module.survey-runner-alerting.slack_alert_sns_arn}"
 }
 
 module "survey-register" {
-  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.2.0"
+  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.4.0"
   env                    = "${var.env}"
   aws_access_key         = "${var.aws_access_key}"
   aws_secret_key         = "${var.aws_secret_key}"
@@ -223,6 +333,7 @@ module "survey-register" {
   container_port         = 8080
   container_tag          = "${var.survey_register_tag}"
   application_min_tasks  = "${var.survey_register_min_tasks}"
+  slack_alert_sns_arn    = "${module.survey-runner-alerting.slack_alert_sns_arn}"
 }
 
 module "survey-runner-database" {
@@ -307,7 +418,7 @@ output "survey_launcher_for_beanstalk" {
 }
 
 output "survey_runner_ecs" {
-  value = "${module.survey-runner-on-ecs.survey_runner_address}"
+  value = "${module.survey-runner-on-ecs.service_address}"
 }
 
 output "survey_launcher_for_ecs" {


### PR DESCRIPTION
### What is the context of this PR?
Migrated away from `eq-survey-runner-deploy` to use `eq-ecs-deploy`.
The means that we will be able to delete https://github.com/ONSdigital/eq-survey-runner-deploy

### How to review
Run `terraform apply` and ensure that Survey Runner deploys correctly on ECS and that the static assets are loaded from the static container.
You can prove this by looking at the headers on the static assets are seeing that they are served by nginx

This also tests https://github.com/ONSdigital/eq-ecs-deploy/pull/14