### PR TITLE
Turn sentry and full story off by default.

### DIFF
--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -385,11 +385,12 @@ variable "publisher_min_tasks" {
 
 variable "author_use_sentry" {
   description   = "Use sentry for bug reporting."
-  default       = "true"
+  default       = "false"
 }
+
 variable "author_use_fullstory" {
   description   = "Use fullstory for capturing user sessions."
-  default       = "true"
+  default       = "false"
 }
 
 variable "author_database_name" {


### PR DESCRIPTION
### What is the context of this PR?
Sentry and full story should be turned off in staging and dev environments.
It is turned on by default at the moment which is causing a lot of noise in our reports (smoke test runs).

This PR changes the defaults so that they are turned off by default.
They are turned on in the eq-deploy project for enabling these surfaces in pre-prod environment.

### How to review
Confirm that changes are correct. Deployment should have sentry and fullstory integration turned off by default.