### PR TITLE
Slack alert Lambda not working on preprod for state change notifications

### DIFF
--- a/survey-runner-alerting/lambda.tf
+++ b/survey-runner-alerting/lambda.tf
@@ -16,6 +16,7 @@ resource "aws_lambda_function" "slack_alert" {
     variables = {
       slack_webhook_path = "${var.slack_webhook_path}"
       slack_channel = "${var.slack_channel}"
+      env_name = "${var.env}"
     }
   }
 }


### PR DESCRIPTION
### What is the context of this PR?
State change notifications were not generating slack alerts on preprod. On prod we seem to have multiple functions.

This function serves both SNS notifications and direct cloud watch alerts. It also removes the previously hard-coded environment string that was present in the deployed version.
