### PR TITLE
Refactor Terraform to remove AWS keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Install roles required by [eq-messaging](https://github.com/ONSdigital/eq-messag
 
 ```
 env="" # your name
-aws_access_key="" # your access key
-aws_secret_key="" # your secret
 aws_key_pair = "" # your name
 
 # ask somebody on the team to send these values to you
+aws_account_id=""
+aws_assume_role_arn=""
 ons_access_ips=""
 certificate_arn=""
 slack_webhook_path=""

--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -2,12 +2,12 @@ variable "env" {
   description = "The environment you wish to use"
 }
 
-variable "aws_secret_key" {
-  description = "Amazon Web Service Secret Key"
+variable "aws_account_id" {
+  description = "Amazon Web Service Account ID"
 }
 
-variable "aws_access_key" {
-  description = "Amazon Web Service Access Key"
+variable "aws_assume_role_arn" {
+  description = "IAM Role to assume on AWS"
 }
 
 # DNS
@@ -356,7 +356,6 @@ variable "survey_launcher_jwt_signing_key_path" {
   default     = "jwt-test-keys/sdc-user-authentication-signing-rrm-private-key.pem"
 }
 
-
 // Author
 variable "author_registry" {
   description = "The docker repository for the author images to run"
@@ -410,17 +409,17 @@ variable "author_api_min_tasks" {
 
 variable "publisher_min_tasks" {
   description = "The minimum number of Publisher tasks to run"
-  default = "1"
+  default     = "1"
 }
 
 variable "author_use_sentry" {
-  description   = "Use sentry for bug reporting."
-  default       = "false"
+  description = "Use sentry for bug reporting."
+  default     = "false"
 }
 
 variable "author_use_fullstory" {
-  description   = "Use fullstory for capturing user sessions."
-  default       = "false"
+  description = "Use fullstory for capturing user sessions."
+  default     = "false"
 }
 
 variable "author_database_name" {

--- a/survey-runner-alerting/aws.tf
+++ b/survey-runner-alerting/aws.tf
@@ -1,14 +1,14 @@
 provider "aws" {
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
+  allowed_account_ids = ["${var.aws_account_id}"]
+  assume_role {
+    role_arn  = "${var.aws_assume_role_arn}"
+  }
   region     = "eu-west-1"
 }
 
 data "aws_caller_identity" "current" {}
 
 terraform {
-  required_version = ">= 0.10.0, < 0.11.0"
-
   backend "s3" {
     region = "eu-west-1"
   }

--- a/survey-runner-alerting/global_vars.tf
+++ b/survey-runner-alerting/global_vars.tf
@@ -2,12 +2,12 @@ variable "env" {
   description = "The environment you wish to use"
 }
 
-variable "aws_secret_key" {
-  description = "Amazon Web Service Secret Key"
+variable "aws_account_id" {
+  description = "Amazon Web Service Account ID"
 }
 
-variable "aws_access_key" {
-  description = "Amazon Web Service Access Key"
+variable "aws_assume_role_arn" {
+  description = "IAM Role to assume on AWS"
 }
 
 variable "slack_webhook_path" {

--- a/survey-runner-application/aws.tf
+++ b/survey-runner-application/aws.tf
@@ -1,6 +1,8 @@
 provider "aws" {
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
+  allowed_account_ids = ["${var.aws_account_id}"]
+  assume_role {
+    role_arn  = "${var.aws_assume_role_arn}"
+  }
   region     = "eu-west-1"
 }
 

--- a/survey-runner-application/global_vars.tf
+++ b/survey-runner-application/global_vars.tf
@@ -2,12 +2,12 @@ variable "env" {
   description = "The environment you wish to use"
 }
 
-variable "aws_secret_key" {
-  description = "Amazon Web Service Secret Key"
+variable "aws_account_id" {
+  description = "Amazon Web Service Account ID"
 }
 
-variable "aws_access_key" {
-  description = "Amazon Web Service Access Key"
+variable "aws_assume_role_arn" {
+  description = "IAM Role to assume on AWS"
 }
 
 variable "vpc_id" {

--- a/survey-runner-database/aws.tf
+++ b/survey-runner-database/aws.tf
@@ -1,14 +1,14 @@
 provider "aws" {
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
+  allowed_account_ids = ["${var.aws_account_id}"]
+  assume_role {
+    role_arn  = "${var.aws_assume_role_arn}"
+  }
   region     = "eu-west-1"
 }
 
 data "aws_caller_identity" "current" {}
 
 terraform {
-  required_version = ">= 0.10.0, < 0.11.0"
-
   backend "s3" {
     region = "eu-west-1"
   }

--- a/survey-runner-database/global_vars.tf
+++ b/survey-runner-database/global_vars.tf
@@ -2,12 +2,12 @@ variable "env" {
   description = "The environment you wish to use"
 }
 
-variable "aws_secret_key" {
-  description = "Amazon Web Service Secret Key"
+variable "aws_account_id" {
+  description = "Amazon Web Service Account ID"
 }
 
-variable "aws_access_key" {
-  description = "Amazon Web Service Access Key"
+variable "aws_assume_role_arn" {
+  description = "IAM Role to assume on AWS"
 }
 
 variable "vpc_id" {

--- a/survey-runner-queue/aws.tf
+++ b/survey-runner-queue/aws.tf
@@ -1,6 +1,8 @@
 provider "aws" {
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
+  allowed_account_ids = ["${var.aws_account_id}"]
+  assume_role {
+    role_arn  = "${var.aws_assume_role_arn}"
+  }
   region     = "eu-west-1"
 }
 
@@ -11,8 +13,6 @@ data "aws_route53_zone" "dns_zone" {
 }
 
 terraform {
-  required_version = ">= 0.10.0, < 0.11.0"
-
   backend "s3" {
     region = "eu-west-1"
   }

--- a/survey-runner-queue/ebs.tf
+++ b/survey-runner-queue/ebs.tf
@@ -1,5 +1,5 @@
 module "ebs_bckup" {
-  source = "github.com/ONSdigital/ebs_bckup?ref=f9b4e8272fe23a6ec30f40755a349e5f0f83c17d"
+  source = "github.com/ONSdigital/ebs_bckup"
   EC2_INSTANCE_TAG = "${var.env}-RabbitMQ"
   RETENTION_DAYS   = "${var.ebs_snapshot_retention_days}"
   unique_name      = "rabbitmq_ebs_snapshot"

--- a/survey-runner-queue/global_vars.tf
+++ b/survey-runner-queue/global_vars.tf
@@ -2,12 +2,12 @@ variable "env" {
   description = "The environment you wish to use"
 }
 
-variable "aws_secret_key" {
-  description = "Amazon Web Service Secret Key"
+variable "aws_account_id" {
+  description = "Amazon Web Service Account ID"
 }
 
-variable "aws_access_key" {
-  description = "Amazon Web Service Access Key"
+variable "aws_assume_role_arn" {
+  description = "IAM Role to assume on AWS"
 }
 
 variable "availability_zones" {

--- a/survey-runner-queue/outputs.tf
+++ b/survey-runner-queue/outputs.tf
@@ -1,7 +1,7 @@
 output "rabbitmq_ip_prime" {
-  value = "${aws_instance.rabbitmq.0.private_ip}"
+  value = "${element(aws_instance.rabbitmq.*.private_ip, 0)}"
 }
 
 output "rabbitmq_ip_failover" {
-  value = "${aws_instance.rabbitmq.1.private_ip}"
+  value = "${element(aws_instance.rabbitmq.*.private_ip, 1)}"
 }

--- a/survey-runner-routing/aws.tf
+++ b/survey-runner-routing/aws.tf
@@ -1,6 +1,8 @@
 provider "aws" {
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
+  allowed_account_ids = ["${var.aws_account_id}"]
+  assume_role {
+    role_arn  = "${var.aws_assume_role_arn}"
+  }
   region     = "eu-west-1"
 }
 
@@ -8,8 +10,6 @@ data "aws_region" "current" {
 }
 
 terraform {
-  required_version = ">= 0.10.0, < 0.11.0"
-
   backend "s3" {
     region = "eu-west-1"
   }

--- a/survey-runner-routing/global_vars.tf
+++ b/survey-runner-routing/global_vars.tf
@@ -2,12 +2,12 @@ variable "env" {
   description = "The environment you wish to use"
 }
 
-variable "aws_secret_key" {
-  description = "Amazon Web Service Secret Key"
+variable "aws_account_id" {
+  description = "Amazon Web Service Account ID"
 }
 
-variable "aws_access_key" {
-  description = "Amazon Web Service Access Key"
+variable "aws_assume_role_arn" {
+  description = "IAM Role to assume on AWS"
 }
 
 variable "vpc_id" {

--- a/survey-runner-vpc/aws.tf
+++ b/survey-runner-vpc/aws.tf
@@ -1,12 +1,12 @@
 provider "aws" {
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
+  allowed_account_ids = ["${var.aws_account_id}"]
+  assume_role {
+    role_arn  = "${var.aws_assume_role_arn}"
+  }
   region     = "eu-west-1"
 }
 
 terraform {
-  required_version = ">= 0.10.0, < 0.11.0"
-
   backend "s3" {
     region = "eu-west-1"
   }

--- a/survey-runner-vpc/global_vars.tf
+++ b/survey-runner-vpc/global_vars.tf
@@ -2,12 +2,12 @@ variable "env" {
   description = "The environment you wish to use"
 }
 
-variable "aws_secret_key" {
-  description = "Amazon Web Service Secret Key"
+variable "aws_account_id" {
+  description = "Amazon Web Service Account ID"
 }
 
-variable "aws_access_key" {
-  description = "Amazon Web Service Access Key"
+variable "aws_assume_role_arn" {
+  description = "IAM Role to assume on AWS"
 }
 
 variable "vpc_cidr_block" {

--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -8,19 +8,19 @@ terraform {
 }
 
 module "survey-runner-alerting" {
-  source             = "./survey-runner-alerting"
-  env                = "${var.env}"
-  aws_access_key     = "${var.aws_access_key}"
-  aws_secret_key     = "${var.aws_secret_key}"
-  slack_webhook_path = "${var.slack_webhook_path}"
-  slack_channel      = "eq-${var.env}-alerts"
+  source              = "./survey-runner-alerting"
+  env                 = "${var.env}"
+  aws_account_id      = "${var.aws_account_id}"
+  aws_assume_role_arn = "${var.aws_assume_role_arn}"
+  slack_webhook_path  = "${var.slack_webhook_path}"
+  slack_channel       = "eq-${var.env}-alerts"
 }
 
 module "survey-runner-on-beanstalk" {
   source                           = "./survey-runner-application"
   env                              = "${var.env}"
-  aws_access_key                   = "${var.aws_access_key}"
-  aws_secret_key                   = "${var.aws_secret_key}"
+  aws_account_id                   = "${var.aws_account_id}"
+  aws_assume_role_arn              = "${var.aws_assume_role_arn}"
   vpc_id                           = "${module.survey-runner-vpc.vpc_id}"
   use_internal_elb                 = "${var.use_internal_elb}"
   eb_instance_type                 = "${var.eb_instance_type}"
@@ -57,10 +57,10 @@ module "survey-runner-on-beanstalk" {
 }
 
 module "eq-ecs" {
-  source                   = "github.com/ONSdigital/eq-terraform-ecs"
+  source                   = "github.com/ONSdigital/eq-terraform-ecs?ref=v4.0"
   env                      = "${var.env}"
-  aws_access_key           = "${var.aws_access_key}"
-  aws_secret_key           = "${var.aws_secret_key}"
+  aws_account_id           = "${var.aws_account_id}"
+  aws_assume_role_arn      = "${var.aws_assume_role_arn}"
   ecs_instance_type        = "${var.ecs_instance_type}"
   certificate_arn          = "${var.certificate_arn}"
   vpc_id                   = "${module.survey-runner-vpc.vpc_id}"
@@ -74,10 +74,10 @@ module "eq-ecs" {
 }
 
 module "survey-runner-on-ecs" {
-  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.5.0"
+  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v2.0"
   env                    = "${var.env}-new"
-  aws_access_key         = "${var.aws_access_key}"
-  aws_secret_key         = "${var.aws_secret_key}"
+  aws_account_id         = "${var.aws_account_id}"
+  aws_assume_role_arn    = "${var.aws_assume_role_arn}"
   vpc_id                 = "${module.survey-runner-vpc.vpc_id}"
   dns_zone_name          = "${var.dns_zone_name}"
   ecs_cluster_name       = "${module.eq-ecs.ecs_cluster_name}"
@@ -197,6 +197,7 @@ module "survey-runner-on-ecs" {
   EOF
 
   task_has_iam_policy = true
+
   task_iam_policy_json = <<EOF
 {
   "Version": "2012-10-17",
@@ -255,32 +256,32 @@ module "survey-runner-on-ecs" {
 }
 
 module "survey-runner-static-on-ecs" {
-  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.5.0"
-  env                    = "${var.env}-new"
-  aws_access_key         = "${var.aws_access_key}"
-  aws_secret_key         = "${var.aws_secret_key}"
-  vpc_id                 = "${module.survey-runner-vpc.vpc_id}"
-  dns_zone_name          = "${var.dns_zone_name}"
-  dns_record_name        = "${var.env}-new-surveys.${var.dns_zone_name}"
-  ecs_cluster_name       = "${module.eq-ecs.ecs_cluster_name}"
-  aws_alb_arn            = "${module.eq-ecs.aws_alb_arn}"
-  aws_alb_listener_arn   = "${module.eq-ecs.aws_alb_listener_arn}"
-  service_name           = "surveys-static"
-  listener_rule_priority = 5
-  docker_registry        = "${var.survey_runner_docker_registry}"
-  container_name         = "eq-survey-runner-static"
-  container_port         = 80
-  container_tag          = "${var.survey_runner_tag}"
-  application_min_tasks  = "${var.survey_runner_min_tasks}"
-  slack_alert_sns_arn    = "${module.survey-runner-alerting.slack_alert_sns_arn}"
+  source                    = "github.com/ONSdigital/eq-ecs-deploy?ref=v2.0"
+  env                       = "${var.env}-new"
+  aws_account_id            = "${var.aws_account_id}"
+  aws_assume_role_arn       = "${var.aws_assume_role_arn}"
+  vpc_id                    = "${module.survey-runner-vpc.vpc_id}"
+  dns_zone_name             = "${var.dns_zone_name}"
+  dns_record_name           = "${var.env}-new-surveys.${var.dns_zone_name}"
+  ecs_cluster_name          = "${module.eq-ecs.ecs_cluster_name}"
+  aws_alb_arn               = "${module.eq-ecs.aws_alb_arn}"
+  aws_alb_listener_arn      = "${module.eq-ecs.aws_alb_listener_arn}"
+  service_name              = "surveys-static"
+  listener_rule_priority    = 5
+  docker_registry           = "${var.survey_runner_docker_registry}"
+  container_name            = "eq-survey-runner-static"
+  container_port            = 80
+  container_tag             = "${var.survey_runner_tag}"
+  application_min_tasks     = "${var.survey_runner_min_tasks}"
+  slack_alert_sns_arn       = "${module.survey-runner-alerting.slack_alert_sns_arn}"
   alb_listener_path_pattern = "/s/*"
 }
 
 module "survey-launcher-for-elastic-beanstalk" {
-  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.5.0"
+  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v2.0"
   env                    = "${var.env}"
-  aws_access_key         = "${var.aws_access_key}"
-  aws_secret_key         = "${var.aws_secret_key}"
+  aws_account_id         = "${var.aws_account_id}"
+  aws_assume_role_arn    = "${var.aws_assume_role_arn}"
   vpc_id                 = "${module.survey-runner-vpc.vpc_id}"
   dns_zone_name          = "${var.dns_zone_name}"
   ecs_cluster_name       = "${module.eq-ecs.ecs_cluster_name}"
@@ -316,10 +317,10 @@ module "survey-launcher-for-elastic-beanstalk" {
 }
 
 module "survey-launcher-for-ecs" {
-  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.5.0"
+  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v2.0"
   env                    = "${var.env}-new"
-  aws_access_key         = "${var.aws_access_key}"
-  aws_secret_key         = "${var.aws_secret_key}"
+  aws_account_id         = "${var.aws_account_id}"
+  aws_assume_role_arn    = "${var.aws_assume_role_arn}"
   vpc_id                 = "${module.survey-runner-vpc.vpc_id}"
   dns_zone_name          = "${var.dns_zone_name}"
   ecs_cluster_name       = "${module.eq-ecs.ecs_cluster_name}"
@@ -355,10 +356,10 @@ module "survey-launcher-for-ecs" {
 }
 
 module "author" {
-  source                           = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.5.0"
+  source                           = "github.com/ONSdigital/eq-ecs-deploy?ref=v2.0"
   env                              = "${var.env}"
-  aws_access_key                   = "${var.aws_access_key}"
-  aws_secret_key                   = "${var.aws_secret_key}"
+  aws_account_id                   = "${var.aws_account_id}"
+  aws_assume_role_arn              = "${var.aws_assume_role_arn}"
   dns_zone_name                    = "${var.dns_zone_name}"
   ecs_cluster_name                 = "${module.eq-ecs.ecs_cluster_name}"
   vpc_id                           = "${module.survey-runner-vpc.vpc_id}"
@@ -425,10 +426,10 @@ module "author" {
 }
 
 module "author-api" {
-  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.5.0"
+  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v2.0"
   env                    = "${var.env}"
-  aws_access_key         = "${var.aws_access_key}"
-  aws_secret_key         = "${var.aws_secret_key}"
+  aws_account_id         = "${var.aws_account_id}"
+  aws_assume_role_arn    = "${var.aws_assume_role_arn}"
   dns_zone_name          = "${var.dns_zone_name}"
   ecs_cluster_name       = "${module.eq-ecs.ecs_cluster_name}"
   vpc_id                 = "${module.survey-runner-vpc.vpc_id}"
@@ -453,10 +454,10 @@ module "author-api" {
 }
 
 module "publisher" {
-  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.5.0"
+  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v2.0"
   env                    = "${var.env}"
-  aws_access_key         = "${var.aws_access_key}"
-  aws_secret_key         = "${var.aws_secret_key}"
+  aws_account_id         = "${var.aws_account_id}"
+  aws_assume_role_arn    = "${var.aws_assume_role_arn}"
   dns_zone_name          = "${var.dns_zone_name}"
   ecs_cluster_name       = "${module.eq-ecs.ecs_cluster_name}"
   vpc_id                 = "${module.survey-runner-vpc.vpc_id}"
@@ -485,10 +486,10 @@ module "publisher" {
 }
 
 module "schema-validator" {
-  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.5.0"
+  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v2.0"
   env                    = "${var.env}"
-  aws_access_key         = "${var.aws_access_key}"
-  aws_secret_key         = "${var.aws_secret_key}"
+  aws_account_id         = "${var.aws_account_id}"
+  aws_assume_role_arn    = "${var.aws_assume_role_arn}"
   vpc_id                 = "${module.survey-runner-vpc.vpc_id}"
   dns_zone_name          = "${var.dns_zone_name}"
   ecs_cluster_name       = "${module.eq-ecs.ecs_cluster_name}"
@@ -506,10 +507,10 @@ module "schema-validator" {
 }
 
 module "survey-register" {
-  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v1.5.0"
+  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v2.0"
   env                    = "${var.env}"
-  aws_access_key         = "${var.aws_access_key}"
-  aws_secret_key         = "${var.aws_secret_key}"
+  aws_account_id         = "${var.aws_account_id}"
+  aws_assume_role_arn    = "${var.aws_assume_role_arn}"
   vpc_id                 = "${module.survey-runner-vpc.vpc_id}"
   dns_zone_name          = "${var.dns_zone_name}"
   ecs_cluster_name       = "${module.eq-ecs.ecs_cluster_name}"
@@ -528,8 +529,8 @@ module "survey-register" {
 module "survey-runner-database" {
   source                           = "./survey-runner-database"
   env                              = "${var.env}"
-  aws_access_key                   = "${var.aws_access_key}"
-  aws_secret_key                   = "${var.aws_secret_key}"
+  aws_account_id                   = "${var.aws_account_id}"
+  aws_assume_role_arn              = "${var.aws_assume_role_arn}"
   vpc_id                           = "${module.survey-runner-vpc.vpc_id}"
   application_cidrs                = "${concat(var.ecs_application_cidrs, var.application_cidrs)}"
   multi_az                         = "${var.multi_az}"
@@ -549,8 +550,8 @@ module "survey-runner-database" {
 module "author-database" {
   source                           = "./survey-runner-database"
   env                              = "${var.env}"
-  aws_access_key                   = "${var.aws_access_key}"
-  aws_secret_key                   = "${var.aws_secret_key}"
+  aws_account_id                   = "${var.aws_account_id}"
+  aws_assume_role_arn              = "${var.aws_assume_role_arn}"
   vpc_id                           = "${module.survey-runner-vpc.vpc_id}"
   application_cidrs                = "${var.ecs_application_cidrs}"
   multi_az                         = "${var.multi_az}"
@@ -570,8 +571,8 @@ module "author-database" {
 module "survey-runner-queue" {
   source                       = "./survey-runner-queue"
   env                          = "${var.env}"
-  aws_access_key               = "${var.aws_access_key}"
-  aws_secret_key               = "${var.aws_secret_key}"
+  aws_account_id               = "${var.aws_account_id}"
+  aws_assume_role_arn          = "${var.aws_assume_role_arn}"
   vpc_id                       = "${module.survey-runner-vpc.vpc_id}"
   queue_cidrs                  = "${var.queue_cidrs}"
   application_cidrs            = "${concat(var.ecs_application_cidrs, var.application_cidrs)}"
@@ -596,8 +597,8 @@ module "survey-runner-queue" {
 module "survey-runner-routing" {
   source              = "./survey-runner-routing"
   env                 = "${var.env}"
-  aws_access_key      = "${var.aws_access_key}"
-  aws_secret_key      = "${var.aws_secret_key}"
+  aws_account_id      = "${var.aws_account_id}"
+  aws_assume_role_arn = "${var.aws_assume_role_arn}"
   public_cidrs        = "${var.public_cidrs}"
   vpc_id              = "${module.survey-runner-vpc.vpc_id}"
   internet_gateway_id = "${module.survey-runner-vpc.internet_gateway_id}"
@@ -605,19 +606,19 @@ module "survey-runner-routing" {
 }
 
 module "survey-runner-vpc" {
-  source         = "./survey-runner-vpc"
-  env            = "${var.env}"
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  vpc_cidr_block = "${var.vpc_cidr_block}"
-  database_cidrs = "${var.database_cidrs}"
+  source              = "./survey-runner-vpc"
+  env                 = "${var.env}"
+  aws_account_id      = "${var.aws_account_id}"
+  aws_assume_role_arn = "${var.aws_assume_role_arn}"
+  vpc_cidr_block      = "${var.vpc_cidr_block}"
+  database_cidrs      = "${var.database_cidrs}"
 }
 
 module "survey-runner-dynamodb" {
-  source                                 = "github.com/ONSdigital/eq-terraform-dynamodb"
+  source                                 = "github.com/ONSdigital/eq-terraform-dynamodb?ref=v2.0"
   env                                    = "${var.env}"
-  aws_access_key                         = "${var.aws_access_key}"
-  aws_secret_key                         = "${var.aws_secret_key}"
+  aws_account_id                         = "${var.aws_account_id}"
+  aws_assume_role_arn                    = "${var.aws_assume_role_arn}"
   slack_alert_sns_arn                    = "${module.survey-runner-alerting.slack_alert_sns_arn}"
   submitted_responses_min_read_capacity  = 1
   submitted_responses_max_read_capacity  = 100

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,8 +1,8 @@
 env=""
-aws_access_key=""
-aws_secret_key=""
-aws_key_pair = ""
+aws_account_id=""
+aws_assume_role_arn=""
+aws_key_pair=""
 
 ons_access_ips=""
 certificate_arn=""
-slack_webhook_path = ""
+slack_webhook_path=""


### PR DESCRIPTION
### What is the context of this PR?
A suggested refactor to the Terraform scripts so that we no longer need to supply AWS keys.
Instead the keys configured on your local machine via `aws configure` will be used.
On Concourse the instance profile attached to the box will allow access to assume an IAM role to run the scripts.
The assumption of an IAM role can be granted across AWS accounts so we wont need to generate Keys for PreProd and Prod, we can just request temporary credentials from the Concourse box.
This should make things more secure as there are no keys that we need to protect.

### How to review
Have a look at the approach, do some general googling, run it and see if it works for you?
