### PR TITLE
Increase evaluation window of rabbit cluster status alarm

### DIFF
--- a/survey-runner-queue/cloudwatch.tf
+++ b/survey-runner-queue/cloudwatch.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_metric_alarm" "rabbitmq_cluster_status" {
   count                     = 2
   alarm_name                = "${var.env}-rabbitmq${count.index + 1}-cluster-alert"
-  evaluation_periods        = "2"
+  evaluation_periods        = "3"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   metric_name               = "${var.env}-rabbitmq${count.index + 1}"
   namespace                 = "RabbitMQClusterStatus"


### PR DESCRIPTION
### What is the context of this PR?
The rabbit instances both run a script every 5 minutes that pushes a metric to CloudWatch (0 or 1 depending if the cluster is healthy or not). If the metric does not get pushed then we treat it as a breach and alert to Slack.

The issue here is that on a reasonably frequent basis the alarm is unable to query that metric data and this results in a Slack alert even though the cluster is perfectly healthy.

### How to review
Push to personal AWS environment. Ensure that the x-rabbitmq1-cluster-alert and x-rabbitmq2-cluster-alert are checking the metrics over 3 minutes.