### PR TITLE
Allow launcher to validate schemas

### DIFF
--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -292,6 +292,7 @@ module "survey-launcher-for-elastic-beanstalk" {
   docker_registry        = "${var.survey_launcher_registry}"
   container_name         = "go-launch-a-survey"
   container_port         = 8000
+  healthcheck_path       = "/status"
   container_tag          = "${var.survey_launcher_tag}"
   application_min_tasks  = "${var.survey_launcher_min_tasks}"
   slack_alert_sns_arn    = "${module.survey-runner-alerting.slack_alert_sns_arn}"
@@ -300,6 +301,10 @@ module "survey-launcher-for-elastic-beanstalk" {
       {
         "name": "SURVEY_RUNNER_URL",
         "value": "https://${var.env}-surveys.${var.dns_zone_name}"
+      },
+      {
+        "name": "SCHEMA_VALIDATOR_URL",
+        "value": "${module.schema-validator.service_address}"
       },
       {
         "name": "JWT_ENCRYPTION_KEY_PATH",
@@ -331,6 +336,7 @@ module "survey-launcher-for-ecs" {
   docker_registry        = "${var.survey_launcher_registry}"
   container_name         = "go-launch-a-survey"
   container_port         = 8000
+  healthcheck_path       = "/status"
   container_tag          = "${var.survey_launcher_tag}"
   application_min_tasks  = "${var.survey_launcher_min_tasks}"
   slack_alert_sns_arn    = "${module.survey-runner-alerting.slack_alert_sns_arn}"
@@ -339,6 +345,10 @@ module "survey-launcher-for-ecs" {
       {
         "name": "SURVEY_RUNNER_URL",
         "value": "https://${var.env}-new-surveys.${var.dns_zone_name}"
+      },
+      {
+        "name": "SCHEMA_VALIDATOR_URL",
+        "value": "${module.schema-validator.service_address}"
       },
       {
         "name": "JWT_ENCRYPTION_KEY_PATH",


### PR DESCRIPTION
### What is the context of this PR?
Launcher currently isn't being passed the validator url so it wasn't validating schemas before launch.
This PR enables this validation

### How to review
`/quick-launch?url=` an invalid schema and check that is shows the validation error
eg.
https://jonshaw-new-surveys-launch.dev.eq.ons.digital/quick-launch?url=https://raw.githubusercontent.com/ONSdigital/eq-census-schemas/master/census_household.json