### PR TITLE
Update lambda runtime to nodejs8.10 LTS.

### DIFF
--- a/survey-runner-alerting/lambda.tf
+++ b/survey-runner-alerting/lambda.tf
@@ -9,7 +9,7 @@ resource "aws_lambda_function" "slack_alert" {
   function_name = "${var.env}-slack-alert"
   role = "${aws_iam_role.iam_for_slack_alert.arn}"
   handler = "index.handler"
-  runtime = "nodejs4.3"
+  runtime = "nodejs8.10"
   timeout = "3"
   source_code_hash = "${data.archive_file.slack_alert_zip.output_base64sha256}"
   environment {


### PR DESCRIPTION
### What is the context of this PR?
The staging deploy is failing because the lambda runtime being used for slack alerting has fallen behind and on an old version of Node JS.

This PR updates the version to the current LTS version (8.10).

### How to review
Terraform changes look sensible.
Able to provision the environment successfully in dev.
