### PR TITLE
Increase the min capacity of most hit dynamo tables

### DIFF
--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -669,13 +669,13 @@ module "survey-runner-dynamodb" {
   submitted_responses_max_read_capacity  = 100
   submitted_responses_min_write_capacity = 1
   submitted_responses_max_write_capacity = 100
-  questionnaire_state_min_read_capacity  = 1
+  questionnaire_state_min_read_capacity  = 5
   questionnaire_state_max_read_capacity  = 100
-  questionnaire_state_min_write_capacity = 1
+  questionnaire_state_min_write_capacity = 5
   questionnaire_state_max_write_capacity = 100
-  eq_session_min_read_capacity           = 1
+  eq_session_min_read_capacity           = 5
   eq_session_max_read_capacity           = 100
-  eq_session_min_write_capacity          = 1
+  eq_session_min_write_capacity          = 5
   eq_session_max_write_capacity          = 100
   used_jti_claim_min_read_capacity       = 1
   used_jti_claim_max_read_capacity       = 100


### PR DESCRIPTION
### What is the context of this PR?
Dynamo is throttling in Staging as the min capacity is too low and does not allow time to scale

### How to review
Run in dev and click around quickly?
