### PR TITLE
User t3 instances for ECS

### DIFF
--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -84,7 +84,7 @@ variable "slack_webhook_path" {
 // ECS
 variable "ecs_instance_type" {
   description = "ECS Instance Type"
-  default     = "t2.medium"
+  default     = "t3.medium"
 }
 
 variable "ecs_cluster_min_size" {

--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -666,21 +666,14 @@ module "survey-runner-dynamodb" {
   aws_assume_role_arn                    = "${var.aws_assume_role_arn}"
   slack_alert_sns_arn                    = "${module.survey-runner-alerting.slack_alert_sns_arn}"
   submitted_responses_min_read_capacity  = 1
-  submitted_responses_max_read_capacity  = 100
+  submitted_responses_min_read_capacity  = 1
   submitted_responses_min_write_capacity = 1
-  submitted_responses_max_write_capacity = 100
   questionnaire_state_min_read_capacity  = 5
-  questionnaire_state_max_read_capacity  = 100
   questionnaire_state_min_write_capacity = 5
-  questionnaire_state_max_write_capacity = 100
   eq_session_min_read_capacity           = 5
-  eq_session_max_read_capacity           = 100
   eq_session_min_write_capacity          = 5
-  eq_session_max_write_capacity          = 100
   used_jti_claim_min_read_capacity       = 1
-  used_jti_claim_max_read_capacity       = 100
   used_jti_claim_min_write_capacity      = 1
-  used_jti_claim_max_write_capacity      = 100
 }
 
 output "survey_runner_beanstalk" {

--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -666,7 +666,6 @@ module "survey-runner-dynamodb" {
   aws_assume_role_arn                    = "${var.aws_assume_role_arn}"
   slack_alert_sns_arn                    = "${module.survey-runner-alerting.slack_alert_sns_arn}"
   submitted_responses_min_read_capacity  = 1
-  submitted_responses_min_read_capacity  = 1
   submitted_responses_min_write_capacity = 1
   questionnaire_state_min_read_capacity  = 5
   questionnaire_state_min_write_capacity = 5


### PR DESCRIPTION
 - They are cheaper and faster
 - Removed the max limits on DynamoDB

### How to review
Run it and see that it continues to work as expected.