### PR TITLE
Increase health check grace period to 120 seconds.

### DIFF
--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -382,7 +382,7 @@ module "author" {
   container_port                   = 3000
   container_tag                    = "${var.author_tag}"
   healthcheck_path                 = "/status.json"
-  healthcheck_grace_period_seconds = 60
+  healthcheck_grace_period_seconds = 120
   slack_alert_sns_arn              = "${module.survey-runner-alerting.slack_alert_sns_arn}"
   application_min_tasks            = "${var.author_min_tasks}"
   high_cpu_threshold               = 80


### PR DESCRIPTION
### What is the context of this PR?
Author deployment is failing health check because the build stage is taking more than 60 seconds in ECS.

This task is a temporary fix to [increase the grace period](https://aws.amazon.com/about-aws/whats-new/2017/12/amazon-ecs-adds-elb-health-check-grace-period/) before starting the health check to allow Author time to finish building and spin up the container in ECS.

**A more permanent fix is being planned to improve the start up times for the Author docker container. But this will require more work and a short term fix is required in order to fix the broken Concourse pipeline.**

### How to review
Health check grace period increased to 120 seconds.