### PR TITLE
Disable DynamoDB for session and questionnaire state by default

### DIFF
--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -189,22 +189,22 @@ variable "survey_runner_log_level" {
 
 variable "survey_runner_questionnaire_state_dynamo_read" {
   description = "Whether survey runner should read from DynmoDB for Questionnaire State objects"
-  default     = "True"
+  default     = "False"
 }
 
 variable "survey_runner_questionnaire_state_dynamo_write" {
   description = "Whether survey runner should write to DynmoDB for Questionnaire State objects"
-  default     = "True"
+  default     = "False"
 }
 
 variable "survey_runner_eq_session_dynamo_read" {
   description = "Whether survey runner should read from DynmoDB for EQ Session objects"
-  default     = "True"
+  default     = "False"
 }
 
 variable "survey_runner_eq_session_dynamo_write" {
   description = "Whether survey runner should write to DynmoDB for EQ Session objects"
-  default     = "True"
+  default     = "False"
 }
 
 variable "survey_runner_used_jti_claim_dynamo_read" {


### PR DESCRIPTION
### What is the context of this PR?
DynamoDB is not currently enabled for sessions and questionnaire state in pre-production and production. This should be the same for developer environments until we decide to change that. 

### How to review
Run Terraform and verify that survey runner works and no entries are added to DynamoDB tables.