### PR TITLE
Match DynamoDB settings to production

### DIFF
--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -199,12 +199,12 @@ variable "survey_runner_questionnaire_state_dynamo_write" {
 
 variable "survey_runner_eq_session_dynamo_read" {
   description = "Whether survey runner should read from DynmoDB for EQ Session objects"
-  default     = "False"
+  default     = "True"
 }
 
 variable "survey_runner_eq_session_dynamo_write" {
   description = "Whether survey runner should write to DynmoDB for EQ Session objects"
-  default     = "False"
+  default     = "True"
 }
 
 variable "survey_runner_used_jti_claim_dynamo_read" {


### PR DESCRIPTION
### What is the context of this PR?
eq_session is now in DynamoDB in production so these settings should match
