### PR TITLE
Remove the patch version from the global defaults for pg engine version.

### DIFF
--- a/survey-runner-database/global_vars.tf
+++ b/survey-runner-database/global_vars.tf
@@ -26,7 +26,7 @@ variable "database_allocated_storage" {
 
 variable "database_engine_version" {
   description = "The Postgres database engine version"
-  default     = "9.4.15"
+  default     = "9.4"
 }
 
 variable "allow_major_version_upgrade" {


### PR DESCRIPTION
### What is the context of this PR?
Sets the default version of the postgres engine to 9.4 omitting the patch version to allow for auto patching of the database.

### How to review
Without setting the engine version. The terraform should provision an RDS instance with postgres 9.4 engine.

- [ ] Do all commits have sensible commit messages?
- [ ] Is there documentation or is the code self-describing?
