### PR TITLE
Update to version 7.2 of eq-terraform-ecs module.

### DIFF
--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -17,7 +17,7 @@ module "eq-alerting" {
 }
 
 module "eq-ecs" {
-  source                   = "github.com/ONSdigital/eq-terraform-ecs?ref=v7.0"
+  source                   = "github.com/ONSdigital/eq-terraform-ecs?ref=v7.2"
   env                      = "${var.env}"
   ecs_cluster_name         = "eq-runner"
   aws_account_id           = "${var.aws_account_id}"


### PR DESCRIPTION
### What is the context of this PR?
Recently the AWS Terraform provider released a new version 2.0.
This caused a breaking change to the EQ terraform configuration which is now blocking deployments to staging.

This change updates `eq-terraform-ecs` to version 7.2 which should fix for the breaking change.

### How to review
Ensure that you are running terraform with version 2.0 of the AWS terraform provider (hint: `terraform init --upgrade`).
Ensure that you observe the error on `master`.
Switch to this branch.
Ensure that you can `terraform apply` the `survey-runner.tf` module in a dev environment.
Ensure you can do the basic things e.g. launch a survey, submit response etc.
Remember to run `terraform destroy` after testing.