### PR TITLE
Update default launcher signing key name.

### DIFF
--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -363,7 +363,7 @@ variable "survey_launcher_jwt_encryption_key_path" {
 
 variable "survey_launcher_jwt_signing_key_path" {
   description = "Path to the JWT Signing Key (PEM format)"
-  default     = "jwt-test-keys/sdc-user-authentication-signing-rrm-private-key.pem"
+  default     = "jwt-test-keys/sdc-user-authentication-signing-launcher-private-key.pem"
 }
 
 // Schema Validator


### PR DESCRIPTION
### What is the context of this PR?
This PR updates the developer defaults to point at the new signing key name.
This PR depends on https://github.com/ONSdigital/go-launch-a-survey/pull/133.

### How to review
- Provision environment using terraform with a `terraform apply`.
- Ensure it is possible to launch a survey from the go-launch-a-survey dev page.
