### PR TITLE
Add Google Tag Manager variables

### DIFF
--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -132,6 +132,16 @@ variable "google_analytics_code" {
   default     = ""
 }
 
+variable "google_tag_manager_id" {
+  description = "The google tag manager workspace id"
+  default     = ""
+}
+
+variable "google_tag_manager_environment_id" {
+  description = "The google tag manager environment id"
+  default     = ""
+}
+
 variable "certificate_arn" {
   description = "ARN of the IAM loaded TLS certificate for public ELB"
 }

--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -91,6 +91,14 @@ module "survey-runner-on-ecs" {
         "value": "${var.google_analytics_code}"
       },
       {
+        "name": "EQ_GTM_ID",
+        "value": "${var.google_tag_manager_id"
+      },
+      {
+        "name": "EQ_GTM_ENV_ID",
+        "value": "${var.google_tag_manager_environment_id}"
+      },
+      {
         "name": "SECRETS_S3_BUCKET",
         "value": "${var.survey_runner_s3_secrets_bucket}"
       },


### PR DESCRIPTION
### What is the context of this PR?
This PR is to add the Google Tag Manager variables to enable google tag manager for Runner

This is linked to these PRs
https://github.com/ONSdigital/eq-survey-runner/pull/2071
https://github.com/ONSdigital/eq-deploy/pull/69

### How to review
Review code changes and check they make sense. Then alongside the secrets PR for eq-terraform make sure that tag manager is added when using runner by checking that tags are being fired in gtm and ua.