### PR TITLE
Drop suggest & elasticsearch

### DIFF
--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -326,42 +326,6 @@ module "survey-register" {
   application_min_tasks  = "${var.survey_register_min_tasks}"
   slack_alert_sns_arn    = "${module.eq-alerting.slack_alert_sns_arn}"
 }
-
-module "eq-elasticsearch" {
-  source              = "github.com/ONSdigital/eq-terraform-elasticsearch"
-  env                 = "${var.env}"
-  aws_account_id      = "${var.aws_account_id}"
-  aws_assume_role_arn = "${var.aws_assume_role_arn}"
-  access_list         = "${concat(module.survey-runner-routing.nat_gateway_ips, split(",", var.ons_access_ips))}"
-}
-
-module "eq-suggest-api" {
-  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v4.1"
-  env                    = "${var.env}"
-  aws_account_id         = "${var.aws_account_id}"
-  aws_assume_role_arn    = "${var.aws_assume_role_arn}"
-  vpc_id                 = "${module.survey-runner-vpc.vpc_id}"
-  dns_zone_name          = "${var.dns_zone_name}"
-  ecs_cluster_name       = "${module.eq-ecs.ecs_cluster_name}"
-  aws_alb_arn            = "${module.eq-ecs.aws_external_alb_arn}"
-  aws_alb_listener_arn   = "${module.eq-ecs.aws_external_alb_listener_arn}"
-  service_name           = "lookup-api"
-  listener_rule_priority = 700
-  docker_registry        = "${var.survey_runner_docker_registry}"
-  container_name         = "eq-lookup-api"
-  container_port         = 5000
-  healthcheck_path       = "/status"
-  container_tag          = "${var.suggest_api_tag}"
-  slack_alert_sns_arn    = "${module.eq-alerting.slack_alert_sns_arn}"
-
-  container_environment_variables = <<EOF
-      {
-        "name": "LOOKUP_URL",
-        "value": "https://${module.eq-elasticsearch.suggest-endpoint}/"
-      }
-  EOF
-}
-
 module "survey-runner-database" {
   source                           = "./survey-runner-database"
   env                              = "${var.env}"


### PR DESCRIPTION
### What is the context of this PR?

After a change to `eq-terraform-elasticsearch` the staging pipeline stopped working as the elastic search module requires additional configuration.
https://github.com/ONSdigital/eq-terraform-elasticsearch/pull/3/files

After speaking with @jonnyshaw89 I understand elasticsearch has been made standalone for v3 and was never used other than in staging for v2. So this change drops it and we can take the v3 change when that comes.

### How to review
1. Run `terraform get -update=true`
2. Run `terraform apply` see that it fails complaining of required parameters.
3. Switch to this branch to see that you can successfully deploy runner.
