### PR TITLE
Remove Google Analytics  variables

### DIFF
--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -127,11 +127,6 @@ variable "ons_access_ips" {
   description = "List of IP's or IP ranges to allow access to eQ"
 }
 
-variable "google_analytics_code" {
-  description = "The google analytics UA Code"
-  default     = ""
-}
-
 variable "google_tag_manager_id" {
   description = "The google tag manager workspace id"
   default     = ""

--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -87,10 +87,6 @@ module "survey-runner-on-ecs" {
         "value": "${var.survey_runner_log_level}"
       },
       {
-        "name": "EQ_UA_ID",
-        "value": "${var.google_analytics_code}"
-      },
-      {
         "name": "EQ_GTM_ID",
         "value": "${var.google_tag_manager_id}"
       },


### PR DESCRIPTION
### What is the context of this PR?
This PR is to remove the Google Analytics variables because they have been replaced with Google Tag Manager

### How to review
Make sure changes make sense
