### PR TITLE
Removed survey register config

### DIFF
--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -392,22 +392,6 @@ variable "schema_validator_min_tasks" {
   default     = "1"
 }
 
-// Survey Register
-variable "survey_register_registry" {
-  description = "The docker repository for the Survey Register image to run"
-  default     = "onsdigital"
-}
-
-variable "survey_register_tag" {
-  description = "The tag for the Survey Register image to run"
-  default     = "latest"
-}
-
-variable "survey_register_min_tasks" {
-  description = "The minimum number of Survey Register tasks to run"
-  default     = "1"
-}
-
 // Suggest Cluster
 variable "suggest_api_tag" {
   description = "The tag for the Suggest API image to run"

--- a/survey-runner.tf
+++ b/survey-runner.tf
@@ -315,25 +315,6 @@ module "schema-validator" {
   slack_alert_sns_arn    = "${module.eq-alerting.slack_alert_sns_arn}"
 }
 
-module "survey-register" {
-  source                 = "github.com/ONSdigital/eq-ecs-deploy?ref=v4.1"
-  env                    = "${var.env}"
-  aws_account_id         = "${var.aws_account_id}"
-  aws_assume_role_arn    = "${var.aws_assume_role_arn}"
-  vpc_id                 = "${module.survey-runner-vpc.vpc_id}"
-  dns_zone_name          = "${var.dns_zone_name}"
-  ecs_cluster_name       = "${module.eq-ecs.ecs_cluster_name}"
-  aws_alb_arn            = "${module.eq-ecs.aws_external_alb_arn}"
-  aws_alb_listener_arn   = "${module.eq-ecs.aws_external_alb_listener_arn}"
-  service_name           = "survey-register"
-  listener_rule_priority = 600
-  docker_registry        = "${var.survey_register_registry}"
-  container_name         = "eq-survey-register"
-  container_port         = 8080
-  container_tag          = "${var.survey_register_tag}"
-  application_min_tasks  = "${var.survey_register_min_tasks}"
-  slack_alert_sns_arn    = "${module.eq-alerting.slack_alert_sns_arn}"
-}
 module "survey-runner-database" {
   source                           = "./survey-runner-database"
   env                              = "${var.env}"


### PR DESCRIPTION
### What is the context of this PR?
The author terraform script now spins up a survey register instance meaning this no longer needs to. this PR removes it from the config.

Can probably just be reviewed by running a terraform plan and check no errors rather than needing to spin up the entire thing.